### PR TITLE
allow method chaining via chain()

### DIFF
--- a/lib/protocol.js
+++ b/lib/protocol.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var builder = require('./builder');
 var element = require('./element').element;
+var async = require("async");
 
 console.log(element);
 
@@ -26,6 +27,48 @@ protocol.sessions = methodBuilder({
   , cb: function(cb) { return callbackWithData(cb); }
 });
 
+protocol.chain = function(){
+  var _this = this;
+
+  //add queue if not already here
+  if(!_this._queue){
+    _this._queue = async.queue(function (task, callback) {
+      if(task.args.length > 0 && typeof task.args[task.args.length-1] === "function"){
+        //wrap the existing callback
+        var func = task.args[task.args.length-1];
+        task.args[task.args.length-1] = function(){
+          func.apply(null, arguments);
+          callback();
+        }
+      } else {
+        //add a callback
+        task.args.push(callback);
+      }
+
+      //call the function
+      _this[task.name].apply(_this, task.args);
+    }, 1);
+  }
+
+  var chain = {};
+
+  //builds a placeHolder functions
+  var buildPlaceholder = function(name){
+    return function(){
+      _this._queue.push({name: name, args: Array.prototype.slice.apply(arguments)});
+      return chain;
+    }
+  }
+
+  //fill the chain with placeholders
+  for(var name in _this){
+    if(typeof _this[name] === "function" && name !== "chain"){
+      chain[name] = buildPlaceholder(name);
+    }
+  }
+
+  return chain;
+}
 
 // alternate strategy to get session capabilities
 // extract session capabilities from session list

--- a/package.json
+++ b/package.json
@@ -14,12 +14,14 @@
   , "main" : "./lib/main"
   , "bin" : { "wd" : "./lib/bin.js" }
   , "directories" : { "lib" : "./lib" }
+  , "dependencies" : {
+    "async" : "0.1.22"
+  }
   , "devDependencies" : {
     "nodeunit" : "latest"
     ,"should": "latest"
     ,"coffee-script": "latest"    
     ,"express": "latest"    
-    ,"async": "latest"
     ,"gleak": "latest"        
   }
 }


### PR DESCRIPTION
inspired by soda https://github.com/LearnBoost/soda

Here is an example how you can use this

<pre>
browser
  .chain()
  .init()
  .get(options.config.url + "/")
  .elementById('button', function(err, button){
    browser.clickElement(button)
    .url(function(err, location){
      assert.equal(location.indexOf("/p/") !== -1, true, "Clicking on 'New Pad' doesn't work");
      callback();
    });
  });
</pre>
