### PR TITLE
Renamed incorrect /timeouts/timeouts URL to /timeouts

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -611,7 +611,7 @@ webdriver.prototype.setAsyncScriptTimeout = function(ms, cb) {
 webdriver.prototype.setPageLoadTimeout = function(ms, cb) {
   this._jsonWireCall({
     method: 'POST'
-    , relPath: '/timeouts/timeouts'
+    , relPath: '/timeouts'
     , data: {type: 'page load', ms: ms}
     , cb: this._simpleCallback(cb)
   });


### PR DESCRIPTION
The current version of WD.js has the resource for changing timeouts at /timeouts/timeouts. However, according to the specification, this should be at /timeouts. The change I made simply updates "timeouts" to point to the correct URL.
