### PR TITLE
Support for connecting to Remote WD servers with HTTPS

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -3,6 +3,7 @@ var async = require("async");
 var fs = require("fs");
 var element = require('./element').element;
 var http = require("http");
+var https = require("https");
 var __slice = Array.prototype.slice;
 var JSONWIRE_ERRORS = require('./jsonwire-errors.js');
 
@@ -14,6 +15,7 @@ var webdriver = module.exports = function(remoteWdConfig) {
   this.username = remoteWdConfig.username;
   this.accessKey = remoteWdConfig.accessKey;
   this.basePath = (remoteWdConfig.path || '/wd/hub');
+  this.https = (remoteWdConfig.https || false);
   // default
   this.options = {
     host: remoteWdConfig.host || '127.0.0.1'
@@ -266,7 +268,7 @@ webdriver.prototype.init = function(desired, cb) {
   }
 
   // building request
-  var req = http.request(httpOpts, function(res) {
+  var req = (this.https ? https : http).request(httpOpts, function(res) {
     var data = '';
     res.on('data', function(chunk) {
       data += chunk;
@@ -334,7 +336,7 @@ webdriver.prototype._jsonWireCall = function(opts) {
     );
 
   // building request
-  var req = http.request(httpOpts, cb);
+  var req = (this.https ? https : http).request(httpOpts, cb);
   req.on('error', function(e) { cb(e); });
 
   // writting data


### PR DESCRIPTION
I added the extra boolean field 'https' to the remoteWdConfig object. If true, when building the request object, the 'https' nodejs module is used instead of the 'http' one.
