### PR TITLE
Add JsonWire command /session/:sessionId/frame

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -455,6 +455,15 @@ webdriver.prototype.window = function(windowName, cb) {
   });
 }
 
+webdriver.prototype.frame = function(frameRef, cb) {
+  this._jsonWireCall({
+    method: 'POST'
+    , relPath: '/frame'
+    , cb: this._simpleCallback(cb)
+    , data: { id: frameRef }
+  });
+}
+
 webdriver.prototype.windowHandles = function(cb) {
   this._jsonWireCall({
     method: 'GET'


### PR DESCRIPTION
I've added the JsonWire command `/session/:sessionId/frame` to webdriver.js to support switching frames on the page.

http://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/session/:sessionId/frame

Where's a good place to drop in a unit test for this new function? In particular, I haven't tested the full range of objects this command supports other than integers: `{string|number|null|WebElement JSON Object}`
