### PR TITLE
Update lib/webdriver.js

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -120,14 +120,16 @@ webdriver.prototype._simpleCallback = function(cb) {
       var data = '';
       res.on('data', function(chunk) { data += chunk.toString(); });
       res.on('end', function() {
+        var err;
         if(data == '') {
           // expected behaviour
           return cb(null)
         } else {
           // something wrong
           if(cb!=null){
-            return cb(new Error(
-              {message:'Unexpected data in simpleCallback.', data:data}) );
+            err = new Error('Unexpected data in simpleCallback.');
+            err.data = data;
+            return cb(err);
           }
         }
       });


### PR DESCRIPTION
Invalid use of Error constructor parameters.

    throw new Error({ message: "", data: {}});

This results into the following error message [Object object] because of a toString on the first parameter.
The first argument must be a string.
