### PR TITLE
Set Content-Length header on requests

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -269,6 +269,8 @@ webdriver.prototype.init = function(desired, cb) {
   }
 
   // building request
+  var data = JSON.stringify({desiredCapabilities: _desired});
+  httpOpts.headers['Content-Length'] = data.length;
   var req = (this.https ? https : http).request(httpOpts, function(res) {
     var data = '';
     res.on('data', function(chunk) {
@@ -295,7 +297,7 @@ webdriver.prototype.init = function(desired, cb) {
   req.on('error', function(e) { cb(e); });
 
   // writting data
-  req.write(JSON.stringify({desiredCapabilities: _desired}));
+  req.write(data);
 
   // sending
   req.end();
@@ -336,10 +338,6 @@ webdriver.prototype._jsonWireCall = function(opts) {
       .replace(this.basePath, '')
     );
 
-  // building request
-  var req = (this.https ? https : http).request(httpOpts, cb);
-  req.on('error', function(e) { cb(e); });
-
   // writting data
   var data = '';
   if (opts.data != null) {
@@ -348,6 +346,11 @@ webdriver.prototype._jsonWireCall = function(opts) {
   if (typeof data === 'object') {
     data = JSON.stringify(data);
   }
+  httpOpts.headers['Content-Length'] = data.length;
+  // building request
+  var req = (this.https ? https : http).request(httpOpts, cb);
+  req.on('error', function(e) { cb(e); });
+
   req.write(data);
 
   //sending


### PR DESCRIPTION
Hi,

I am trying to use wd.js with GhostDriver[1] and phantom.js[2] and it wasn't working. The mongoose webserver phantom.js ships with wont read post data unless it also sends a Content-Length header. If you read the HTTP RFC, you should always send a Content-Length header[3].

[1] https://github.com/detro/ghostdriver/
[2] https://github.com/detro/phantomjs/tree/ghostdriver-dev
[3] http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html

Spent all day trying to figure out why it wasn't working for me. :fish:

![Exhausted](http://i.imgur.com/q7Dyb.gif)
