### PR TITLE
Headers no longer ovewritten when using auth

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -282,9 +282,7 @@ webdriver.prototype.init = function(desired, cb) {
   if ((_this.username != null) && (_this.accessKey != null)) {
     var authString = _this.username + ':' + _this.accessKey;
     var buf = new Buffer(authString);
-    httpOpts['headers'] = {
-      'Authorization': 'Basic ' + buf.toString('base64')
-    };
+    httpOpts.headers['Authorization'] = 'Basic ' + buf.toString('base64');
   }
 
   // building request


### PR DESCRIPTION
It seems that the headers field of the HTTP options object was accidentally overwritten if using authorization.
