### PR TITLE
Promise tests fixes and test case for element

### DIFF
--- a/lib/promise-webdriver.js
+++ b/lib/promise-webdriver.js
@@ -3,10 +3,15 @@ var webdriver = require('./webdriver')
   , element = require('./element').element
   , slice = Array.prototype.slice.call.bind(Array.prototype.slice);
 
-var copyFunctions = function(newObj, originalObj) {
+var copyFunctions = function(newObj, originalObj, wrapMatching) {
     // copy all the public functions on the webdriver prototype
     for (var prop in originalObj.prototype) {
         var fn = originalObj.prototype[prop];
+
+        // wrap only elements matching wrapMatching if it is provided
+        if (wrapMatching &&  prop.indexOf(wrapMatching) === -1) {
+            continue;
+        }
         // ordered per performance on
         // http://jsperf.com/compare-typeof-indexof-hasownproperty
         if (typeof fn === 'function' &&
@@ -25,7 +30,6 @@ var promiseElement = function() {
     return element.apply(this, arguments);
 };
 promiseElement.prototype = Object.create(element.prototype);
-copyFunctions(promiseElement, element);
 
 var promiseWebdriver = module.exports = function() {
     // inject promisified element
@@ -35,6 +39,7 @@ var promiseWebdriver = module.exports = function() {
 
 promiseWebdriver.prototype = Object.create(webdriver.prototype);
 copyFunctions(promiseWebdriver, webdriver);
+copyFunctions(promiseElement, element, 'element');
 
 function wrap(fn) {
     return function() {

--- a/test/common/promise-test-base.js
+++ b/test/common/promise-test-base.js
@@ -47,20 +47,33 @@ test = function(remoteWdConfig, desired, markAsPassed) {
           this.timeout(TIMEOUT);
           browser.get("http://admc.io/wd/test-pages/guinea-pig.html").then(function() {
             return browser.title();
-          }).then(function(title) {
+          }).done(function(title) {
             assert.ok(~title.indexOf("I am a page title - Sauce Labs"), "Wrong title!");
             done(null);
           });
         });
       });
-      describe("clicking submit", function(done) {
-        it("submit element should be clicked", function() {
+      describe("getting subelement", function() {
+        it("subelement value should be retrieved", function(done) {
+          this.timeout(TIMEOUT);
+          browser.elementById('the_forms_id').then(function(el) {
+              return el.elementById('unchecked_checkbox');
+          }).then(function(el) {
+              return el.getAttribute('type');
+          }).done(function(value) {
+              assert.equal(value, 'checkbox');
+              done(null);
+          });
+        });
+      });
+      describe("clicking submit", function() {
+        it("submit element should be clicked", function(done) {
           this.timeout(TIMEOUT);
           browser.elementById("submit").then(function(el) {
             return browser.clickElement(el);
           }).then(function() {
             return browser["eval"]("window.location.href");
-          }).then(function(location) {
+          }).done(function(location) {
             assert.ok(~location.indexOf("http://"), "Wrong location!");
             done(null);
           });


### PR DESCRIPTION
promisify only certain element functions,
fix bugs in promise-test-base:
- use 'done' to allow error to be thrown when assertion fails
- call 'done' of 'it', not 'describe'
