### PR TITLE
expose Q to the promise webdriver

### DIFF
--- a/lib/promise-webdriver.js
+++ b/lib/promise-webdriver.js
@@ -34,6 +34,8 @@ promiseElement.prototype = Object.create(element.prototype);
 var promiseWebdriver = module.exports = function() {
     // inject promisified element
     arguments[0].element = promiseElement;
+    // expose Q to the webdriver
+    this.Q = Q;
     return webdriver.apply(this, arguments);
 };
 


### PR DESCRIPTION
this exposes Q to the webdriver so that you can customize the `onerror` functionality to you're liking.

https://github.com/kriskowal/q/blob/c29ca540b693924b4a786e79cc2256941e281229/q.js#L981
