### PR TITLE
Return from all element.js wrapper-functions (for the promise interface)

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -47,7 +47,7 @@ element.prototype.click = function (cb) {
  * @jsonWire POST /session/:sessionId/touch/flick
  */
 element.prototype.flick = function (xoffset, yoffset, speed, cb) {
-    this.browser.flick(this.value, xoffset, yoffset, speed, cb);
+    return this.browser.flick(this.value, xoffset, yoffset, speed, cb);
 };
 
 
@@ -136,7 +136,7 @@ element.prototype.isVisible = function(cb) {
  * @jsonWire GET /session/:sessionId/element/:id/location
  */
 element.prototype.getLocation = function (cb) {
-    this.browser.getLocation(this, cb);
+    return this.browser.getLocation(this, cb);
 };
 
 /**
@@ -145,7 +145,7 @@ element.prototype.getLocation = function (cb) {
  * @jsonWire GET /session/:sessionId/element/:id/size
  */
 element.prototype.getSize = function (cb) {
-    this.browser.getSize(this, cb);
+    return this.browser.getSize(this, cb);
 };
 
 /**
@@ -184,7 +184,7 @@ element.prototype.clear = function(cb) {
  * @jsonWire GET /session/:sessionId/element/:id/css/:propertyName
  */
 element.prototype.getComputedCss = function(styleName, cb) {
-    this.browser.getComputedCss(this, styleName, cb);
+    return this.browser.getComputedCss(this, styleName, cb);
 };
 
 _.each(utils.elementFuncTypes, function(type) {


### PR DESCRIPTION
I'm using the promise interface, and noticed that some element.js functions (like element.getSize) aren't returning promises, so they can't be chained properly.
