### PR TITLE
Add Date.now shim to wait-for-cond-in-browser for non-ES5 browsers

### DIFF
--- a/browser-scripts/wait-for-cond-in-browser.js
+++ b/browser-scripts/wait-for-cond-in-browser.js
@@ -2,6 +2,14 @@ var args = Array.prototype.slice.call(arguments, 0);
 var condExpr = args[0], timeout = args[1], 
     poll = args[2], cb = args[3];
 
+// Shim Date.now if browser engine does not support it.
+// (taken from MDN page).
+if (!Date.now) {
+  Date.now = function now() {
+    return new Date().getTime();
+  };
+}
+
 // recursive implementation
 var waitForConditionImpl = function(conditionExpr, limit, poll, cb) {
   


### PR DESCRIPTION
Was getting errors in older IE browsers when using waitForConditionInBrowser. I realized it's because the wait-for-cond-in-browser.js file is executed in the browser and it uses Date.now which is not supported in those older IEs. This just adds a quick shim for that if it's not present, from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now
