### PR TITLE
Add a mechanism for queueAdd to run a function asynchronously with a callback

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -391,12 +391,16 @@ webdriver.prototype.chain = function(obj){
     _this._queue = async.queue(function (task, callback) {
       if(task.args.length > 0 && typeof task.args[task.args.length-1] === "function"){
         //wrap the existing callback
-        var func = task.args[task.args.length-1];
-        task.args[task.args.length-1] = function(err) {
+        //if this is queueAddAsync, we instead create a callback that will be
+        //passed through to the function provided
+        var cb_arg = (task.name === 'queueAddAsync' ? 1 : task.args.length - 1);
+        var func = task.args[cb_arg];
+        task.args[cb_arg] = function(err) {
           // if the chain user has their own callback, we will not invoke
           // the onError handler, supplying your own callback suggests you
           // handle the error on your own.
-          func.apply(null, arguments);
+          if (func)
+            func.apply(null, arguments);
           if (!_this._chainHalted) { callback(); }
         };
       } else {
@@ -470,6 +474,11 @@ webdriver.prototype.queueAdd = function(func){
   } else {
     func();
   }
+  return this.chain;
+};
+
+webdriver.prototype.queueAddAsync = function(func, cb) {
+  func(cb);
   return this.chain;
 };
 


### PR DESCRIPTION
queueAdd must be called like:

browser.queueAdd(function(cb) {
  do_something_async(cb);
}, function() {
  do_something_synchronously(cb);
});

The second synchronous function may be empty, but there must be a
function provided for the second argument to queueAdd for the first
function to be treated asynchronously.
