### PR TITLE
Add queueAddAsync command

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -391,12 +391,16 @@ webdriver.prototype.chain = function(obj){
     _this._queue = async.queue(function (task, callback) {
       if(task.args.length > 0 && typeof task.args[task.args.length-1] === "function"){
         //wrap the existing callback
-        var func = task.args[task.args.length-1];
-        task.args[task.args.length-1] = function(err) {
+        //if this is queueAddAsync, we instead create a callback that will be
+        //passed through to the function provided
+        var cb_arg = (task.name === 'queueAddAsync' ? 1 : task.args.length - 1);
+        var func = task.args[cb_arg];
+        task.args[cb_arg] = function(err) {
           // if the chain user has their own callback, we will not invoke
           // the onError handler, supplying your own callback suggests you
           // handle the error on your own.
-          func.apply(null, arguments);
+          if (func)
+            func.apply(null, arguments);
           if (!_this._chainHalted) { callback(); }
         };
       } else {
@@ -462,6 +466,11 @@ webdriver.prototype.next = function(){
 
 webdriver.prototype.queueAdd = function(func){
   func();
+  return this.chain;
+};
+
+webdriver.prototype.queueAddAsync = function(func, cb) {
+  func(cb);
   return this.chain;
 };
 


### PR DESCRIPTION
When chaining commands, it is sometimes necessary to have an async
command that calls a provided callback when complete. For example:

driver.chain()
  ...
  .queueAddAsync(function(cb) {
    http.get('http://google.com', function(res) {
      if (res.statusCode === 200)
        cb();
      else
        cb(new Error('Failed to reach google.com'));
    });
  })
  ...

This commit adds the queueAddAsync functionality. It may be called with
an optional second argument function that is run synchronously after
the first function completes. This mimics the behavior of all the other
wd methods.
