### PR TITLE
Add `submit` element instance method

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,8 +742,13 @@ POST <a href="http://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/sess
 Submit a FORM element.
 </td>
 <td style="border: 1px solid #ccc; padding: 5px;">
+<p>
 submit(element, cb) -&gt; cb(err)<br>
 Submit a `FORM` element.<br>
+</p>
+<p>
+element.submit(cb) -&gt; cb(err)<br>
+</p>
 </td>
 </tr>
 <tr>

--- a/doc/jsonwire-full-mapping.md
+++ b/doc/jsonwire-full-mapping.md
@@ -571,8 +571,13 @@ POST <a href="http://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/sess
 Submit a FORM element.
 </td>
 <td style="border: 1px solid #ccc; padding: 5px;">
+<p>
 submit(element, cb) -&gt; cb(err)<br>
 Submit a `FORM` element.<br>
+</p>
+<p>
+element.submit(cb) -&gt; cb(err)<br>
+</p>
 </td>
 </tr>
 <tr>

--- a/doc/jsonwire-mapping.md
+++ b/doc/jsonwire-mapping.md
@@ -517,8 +517,13 @@ POST <a href="http://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/sess
 Submit a FORM element.
 </td>
 <td style="border: 1px solid #ccc; padding: 5px;">
+<p>
 submit(element, cb) -&gt; cb(err)<br>
 Submit a `FORM` element.<br>
+</p>
+<p>
+element.submit(cb) -&gt; cb(err)<br>
+</p>
 </td>
 </tr>
 <tr>

--- a/lib/element.js
+++ b/lib/element.js
@@ -217,6 +217,15 @@ element.prototype.clear = function(cb) {
 };
 
 /**
+ * element.submit(cb) -> cb(err)
+ *
+ * @jsonWire POST /session/:sessionId/element/:id/submit
+ */
+element.prototype.submit = function(cb) {
+    return this.browser.submit(this, cb);
+};
+
+/**
  * element.getComputedCss(cssProperty , cb) -> cb(err, value)
  *
  * @jsonWire GET /session/:sessionId/element/:id/css/:propertyName


### PR DESCRIPTION
The `submit` method was only available as a `webdriver` static method.

Considering that:

> The submit command may also be applied to any element that is a descendant of a FORM element.
> (from the [JsonWireProtocol](http://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/submit)) 

It is quite nice to be able to fill a field and submit it on the same reference.

This changeset adds `element.submit`, mapping it to the corresponding `webdriver` method, just like other mapped methods.
