### PR TITLE
Add `element.doubleclick` instance method

### DIFF
--- a/doc/jsonwire-full-mapping.md
+++ b/doc/jsonwire-full-mapping.md
@@ -1243,6 +1243,14 @@ element.sendKeys(keys, cb) -&gt; cb(err)<br>
 EXTRA
 </td>
 <td style="border: 1px solid #ccc; padding: 5px;">
+element.doubleClick(cb) -&gt; cb(err)<br>
+</td>
+</tr>
+<tr>
+<td style="border: 1px solid #ccc; padding: 5px;">
+EXTRA
+</td>
+<td style="border: 1px solid #ccc; padding: 5px;">
 isVisible(cb) -&gt; cb(err, boolean)<br>
 </td>
 </tr>

--- a/doc/jsonwire-mapping.md
+++ b/doc/jsonwire-mapping.md
@@ -1027,6 +1027,14 @@ element.sendKeys(keys, cb) -&gt; cb(err)<br>
 EXTRA
 </td>
 <td style="border: 1px solid #ccc; padding: 5px;">
+element.doubleClick(cb) -&gt; cb(err)<br>
+</td>
+</tr>
+<tr>
+<td style="border: 1px solid #ccc; padding: 5px;">
+EXTRA
+</td>
+<td style="border: 1px solid #ccc; padding: 5px;">
 isVisible(cb) -&gt; cb(err, boolean)<br>
 </td>
 </tr>

--- a/lib/element.js
+++ b/lib/element.js
@@ -80,6 +80,18 @@ element.prototype.click = function (cb) {
 };
 
 /**
+ * element.doubleClick(cb) -> cb(err)
+ *
+ */
+element.prototype.doubleclick = function(cb) {
+    return this.browser.moveTo(this, function(err) {
+      this.browser.doubleclick(cb);
+    }.bind(this));
+};
+
+element.prototype.doubleClick = element.prototype.doubleclick;
+
+/**
  * element.flick(xoffset, yoffset, speed, cb) -> cb(err)
  *
  * @jsonWire POST /session/:sessionId/touch/flick

--- a/test/common/element-test-base.js
+++ b/test/common/element-test-base.js
@@ -139,6 +139,29 @@ test = function(remoteWdConfig, desired) {
       });
     });
   });
+  describe("element.doubleClick", function() {
+    it("element should be double-clicked", function(done) {
+      browser.elementByCss("#click a", function(err, anchor) {
+        should.not.exist(err);
+        should.exist(anchor);
+        async.series([
+          executeCoffee(browser, "jQuery ->\n  a = $('#click a')\n  a.dblclick ->\n    a.html 'doubleclicked'\n    false\n"), function(done) {
+            textShouldEqual(browser, anchor, "clicked", done);
+          }, function(done) {
+            anchor.doubleClick(function(err) {
+              should.not.exist(err);
+              done(null);
+            });
+          }, function(done) {
+            textShouldEqual(browser, anchor, "doubleclicked", done);
+          }
+        ], function(err) {
+          should.not.exist(err);
+          done(null);
+        });
+      });
+    });
+  });
   describe("element.getTagName", function() {
     it("should get correct tag name", function(done) {
       async.series([


### PR DESCRIPTION
The `doubleclick` method was only available as a webdriver static method.

This changeset adds `element.doublelick`, wrapping the corresponding `moveto` + `doubleclick` static calls.
