### PR TITLE
Updating README to reflect current options

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,16 +106,19 @@ var browser = wd.remote("ondemand.saucelabs.com", 80, "username", "apikey");
 var browser = wd.remote()
 // or
 var browser = wd.remote({
-  hostname: '127.0.0.1',
+  host: '127.0.0.1',
   port: 4444,
-  user: 'username',
-  pwd: 'password',
+  username: 'username',
+  accessKey: 'password',
 });
-// or
+// or include everything
 var browser = wd.remote({
-  hostname: '127.0.0.1',
+  host: '127.0.0.1',
   port: 4444,
-  auth: 'username:password',
+  username: 'username',
+  accessKey: 'password',
+  https: false,
+  path: '/wd/hub'
 });
 </pre>
 


### PR DESCRIPTION
The current README doesn't represent the real configuration options available when using an object to initialize wd.remote().

Included is an update to the current README to reflect the correct configuration object keys
