### PR TITLE
Replace Date.now with non-ES5 compatible getTime instead of a shim

### DIFF
--- a/browser-scripts/wait-for-cond-in-browser.js
+++ b/browser-scripts/wait-for-cond-in-browser.js
@@ -2,18 +2,11 @@ var args = Array.prototype.slice.call(arguments, 0);
 var condExpr = args[0], timeout = args[1], 
     poll = args[2], cb = args[3];
 
-// shim Date.now if absent.
-if (!Date.now) {
-  Date.now = function now() {
-    return new Date().getTime();
-  };
-}
-
 // recursive implementation
 var waitForConditionImpl = function(conditionExpr, limit, poll, cb) {
   
   // timeout check
-  if (Date.now() < limit) {
+  if ((new Date().getTime()) < limit) {
     // condition check
     var res = eval(conditionExpr);
     if (res === true ) {
@@ -33,5 +26,5 @@ var waitForConditionImpl = function(conditionExpr, limit, poll, cb) {
 };
 
 // calling impl
-var limit = Date.now() + timeout;  
+var limit = (new Date().getTime()) + timeout;  
 waitForConditionImpl(condExpr, limit, poll, cb);


### PR DESCRIPTION
I originally submitted this pull request to shim Date.now: https://github.com/admc/wd/pull/130

But I thought about it again recently and I imagine you don't want to shim an older browser to provide functionality it doesn't have just to make the test framework work (what if the code being tested uses Date.now and should fail in those browsers but would now pass?). So this just replaces the usage of Date.now in the file with the more broadly compatible new Date().getTime().
