### PR TITLE
Fix auto upload

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -60,9 +60,9 @@ element.prototype.sendKeys = function (keys, cb) {
   _isLocalFile(path, function (err, isLocalFile) {
     if(err){ return cb(err); }
     if(isLocalFile) {
-      _this.browser.uploadFile(path, function (err) {
+      _this.browser.uploadFile(path, function (err, distantFilePath) {
         if(err){ return cb(err); }
-        return _this.browser.type(_this, keys, cb);
+        return _this.browser.type(_this, distantFilePath, cb);
       });
     } else {
       return _this.browser.type(_this, keys, cb);


### PR DESCRIPTION
Recent changes (337d24e05f8b12d10b5a9429003273eaf67362e9) have fixed a problem with `node-zip` in #122, allowing file upload to work properly.

However, the automatic detection of local files to upload is still broken. Indeed, even though the file is properly uploaded, the file path typed in is still the local one.

This changeset makes the _distant_ file path typed if the file was automatically uploaded.
