### PR TITLE
More robust sessionID parsing. 

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -295,7 +295,7 @@ webdriver.prototype.init = function() {
       }
       return;
     }
-    var locationArr = res.headers.location.split('/');
+    var locationArr = res.headers.location.replace(/\/$/, '').split('/');
     _this.sessionID = locationArr[locationArr.length - 1];
     _this.emit('status', '\nDriving the web on session: ' + _this.sessionID + '\n');
 


### PR DESCRIPTION
Now handles sessionID's that are returned with a trailing slash.

This is needed to work with the [IPhoneDriver](https://code.google.com/p/selenium/wiki/IPhoneDriver) (now deprecated).
