### PR TITLE
Strip trailing slashes from server urls:

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -54,7 +54,12 @@ function buildConfigUrl(remoteWdConfig)
     pathname: '/wd/hub'    
   }); 
 
-  return url.parse(url.format(configUrl));
+  // strip any trailing slashes from pathname
+  var parsed = url.parse(url.format(configUrl));
+  if (parsed.pathname[parsed.pathname.length - 1] === '/') {
+  	parsed.pathname = parsed.pathname.slice(0, parsed.pathname.length - 1)
+  }
+  return parsed;
 }
 
 // parses server parameters


### PR DESCRIPTION
wd assumes the pathname of the server's url does not end in a slash (for instance, to generate the new session url the logic is pathname += '/session').  However, node's url format utility automatically adds a slash for empty pathnames, so for instance 'http://localhost' becomes 'http://localhost/'.  This commit modifies buildConfigUrl to guarantee that there is no trailing slash in the returned url object.
