### PR TITLE
Fix name of argument to buttonDown/Up and document it in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1074,10 +1074,11 @@ Buttons: {left: 0, middle: 1 , right: 2}<br>
 <tr>
 <td style="border: 1px solid #ccc; padding: 5px;">
 POST <a href="http://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/session/:sessionId/buttondown">/session/:sessionId/buttondown</a><br>
-Click and hold the left mouse button (at the coordinates set by the last moveto command).
+Click and hold any mouse button (at the coordinates set by the last moveto command).
 </td>
 <td style="border: 1px solid #ccc; padding: 5px;">
-buttonDown(cb) -&gt; cb(err)<br>
+buttonDown(button, cb) -&gt; cb(err)<br>
+Buttons: {left: 0, middle: 1 , right: 2}<br>
 </td>
 </tr>
 <tr>
@@ -1086,7 +1087,8 @@ POST <a href="http://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/sess
 Releases the mouse button previously held (where the mouse is currently at).
 </td>
 <td style="border: 1px solid #ccc; padding: 5px;">
-buttonUp(cb) -&gt; cb(err)<br>
+buttonUp(button, cb) -&gt; cb(err)<br>
+Buttons: {left: 0, middle: 1 , right: 2}<br>
 </td>
 </tr>
 <tr>

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -1523,8 +1523,8 @@ webdriver.prototype.moveTo = function() {
 };
 
 /**
- * buttonDown(number ,cb) -> cb(err)
- * number is optional.
+ * buttonDown(button ,cb) -> cb(err)
+ * button is optional.
  * {LEFT = 0, MIDDLE = 1 , RIGHT = 2}.
  * LEFT if not specified.
  *
@@ -1533,18 +1533,18 @@ webdriver.prototype.moveTo = function() {
 webdriver.prototype.buttonDown = function() {
   var fargs = utils.varargs(arguments);
   var cb = fargs.callback,
-      number = fargs.all[0];
+      button = fargs.all[0];
   this._jsonWireCall({
     method: 'POST'
     , relPath: '/buttondown'
-    , data: {number: number}
+    , data: {button: button}
     , cb: this._simpleCallback(cb)
   });
 };
 
 /**
- * buttonUp(number, cb) -> cb(err)
- * number is optional.
+ * buttonUp(button, cb) -> cb(err)
+ * button is optional.
  * {LEFT = 0, MIDDLE = 1 , RIGHT = 2}.
  * LEFT if not specified.
  *
@@ -1553,11 +1553,11 @@ webdriver.prototype.buttonDown = function() {
 webdriver.prototype.buttonUp = function() {
   var fargs = utils.varargs(arguments);
   var cb = fargs.callback,
-      number = fargs.all[0];
+      button = fargs.all[0];
   this._jsonWireCall({
     method: 'POST'
     , relPath: '/buttonup'
-    , data: {number: number}
+    , data: {button: button}
     , cb: this._simpleCallback(cb)
   });
 };


### PR DESCRIPTION
The button argument to `buttonDown` and `buttonUp` should be `button` instead of `number`:
- <a href="http://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/session/:sessionId/buttondown">/session/:sessionId/buttondown</a>
- <a href="http://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/session/:sessionId/buttonup">/session/:sessionId/buttonup</a>

I fixed this and also updated the relevant documentation in the README.
