### PR TITLE
only put body and content-length for POST requests

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -233,9 +233,11 @@ webdriver.prototype._newHttpOpts = function(method) {
   if (opts.method === 'POST') {
     opts.headers['Content-Type'] = 'application/json; charset=UTF-8'; }
   opts.prepareToSend = function(url, data) {
-    this.headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
+    if (opts.method == 'POST') {
+      this.headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
+      this.body = data;
+    }
     this.url = url;
-    this.body = data;
   };
 
   return opts;


### PR DESCRIPTION
This one has me a little baffled because it was working fine until recently and I can't figure out which piece of the puzzle has changed. I'm suspecting it might be a Node-core thing, I'm on 0.10.18, I've tried .17 and also 0.11 but nothing older. I don't _think_ this is a problem with mikeal/request.

wd -> SauceConnect.jar -> SauceLabs is broken for non-POST requests, if you watch the requests then it appears that SauceConnect isn't responding at all to those requests.

Removing the Content-Length header and `body` from the requests that aren't POST fixes the issue so I my wild guess is that perhaps Node used to write a body for all request types that had a Content-Length but it doesn't any more (which is correct). SauceConnect is probably just being sloppy and seeing that there is a Content-Length it's waiting for a body which never comes.... **_perhaps!**_

Anyway, this PR fixes the issue, I don't think wd is using anything other than POST that requires a Content-Length so the `== 'POST'` should be good enough I hope.
