### PR TITLE
allow elements to be serialized for execute, etc

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -21,6 +21,10 @@ element.prototype.toString = function () {
     return String(this.value);
 };
 
+element.prototype.toJSON = function () {
+    return { ELEMENT: this.value };
+};
+
 /**
  * element.type(keys, cb) -> cb(err)
  *


### PR DESCRIPTION
adding `element.prototype.toJSON` should allow for passing elements as args
to execute etc.  as an example
https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/execute_async
explains how args can be a WebElement reference and this PR provides suitable
serialization to make this work.
