### PR TITLE
Fix typo in code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ browser
   .get("http://admc.io/wd/test-pages/guinea-pig.html")
   .title()
     .should.become('I am a page title - Sauce Labs')
-  .elementById('ai am a link')
+  .elementById('i am a link')
   .click()
   .eval("window.location.href")
     .should.eventually.include('guinea-pig2')


### PR DESCRIPTION
The full code (`examples/promise/chrome.js`) is correct, the typo was just in the README.
