### PR TITLE
add required chai-as-promised version to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Incompatibilities:
 
   - There is a new method to call, `wd.rewrap()`, to propagate async monkey 
   patching to promise. (see [here](https://github.com/admc/wd/blob/master/examples/promise/monkey.patch-with-async.js#L35) and the monkey patch section below)
-  - The chai-as-promised setup has changed in v4, look out for the `transferPromiseness` 
+  - The chai-as-promised setup has changed in v4, look out for the `transferPromiseness` (Requires chai-as-promised 4.1.0 or greater)
   line in the examples. (see [here](https://github.com/admc/wd/blob/master/examples/promise/chrome.js#L15))
 
 ### 0.2.3 (In progress) 


### PR DESCRIPTION
I was going crazy trying to figure out why "transferPromiseness" was
not working, until I realized it was due to an older version of
chai-as-promised that I was using.  Since this new API is dependent on
this fix:
https://github.com/domenic/chai-as-promised/pull/38 , I've added a
quick blurb in the README to help others avoid the same mistake.
