### PR TITLE
Add `saveScreenshot` API which actually saves to the filesystem.

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -1181,6 +1181,23 @@ webdriver.prototype.takeScreenshot = function() {
   });
 };
 
+/**
+ * saveScreenshot(fileName, cb)
+ *
+ * Calls the official jsonWire API for 'takeScreenshot', which
+ * returns base64 data, and saves it to a real image on the
+ * local filesystem, using the specified file name.
+ *
+ * @param fileName
+ * @param cb
+ */
+webdriver.prototype.saveScreenshot = function(fileName) {
+    var cb = findCallback(arguments);
+    this.takeScreenshot().then(function(base64Data) {
+        require("fs").writeFile(fileName + ".png", base64Data, 'base64', cb);
+    });
+};
+
 // adding all elementBy... , elementsBy... function
 
 webdriver.prototype._buildBySuffixMethods = function(type, prototype, singular, plural) {


### PR DESCRIPTION
The `takeScreenshot` API just returns base64 encoded data of the screenshot.
This method is more user-friendly and actually saves the image to the filesystem.

Usage:

``` js
browser
  .elementById("login")
  .click()
  .saveScreenshot("Logged_In")   // saves Logged_In.png to the filesystem
  .elementById("logout" )
  .click()
  .saveScreenshot("Logged_Out");   // saves Logged_Out.png to the filesystem
```
