### PR TITLE
Fix isVisible and is hidden asserters to use isDisplayed method

### DIFF
--- a/lib/asserters.js
+++ b/lib/asserters.js
@@ -43,9 +43,9 @@ function textInclude(content) {
  */
 var isVisible = new Asserter(
   function(el,cb) {
-    el.isVisible(function(err, isVisible) {
+    el.isDisplayed(function(err, displayed) {
       if(err) { return cb(err); }
-      cb(null, isVisible);
+      cb(null, displayed);
     });
   }
 );
@@ -57,9 +57,9 @@ var isVisible = new Asserter(
  */
 var isHidden = new Asserter(
   function(el,cb) {
-    el.isVisible(function(err, isVisible) {
+    el.isDisplayed(function(err, displayed) {
       if(err) { return cb(err); }
-      cb(null, !isVisible);
+      cb(null, !displayed);
     });
   }
 );

--- a/test/midway/asserters-specs.js
+++ b/test/midway/asserters-specs.js
@@ -22,6 +22,19 @@ describe('asserters ' + env.ENV_DESC, function() {
     ' $("#theDiv .child").show();\n' +
     '}, arguments[0]);\n';
 
+  var appendChildHideAndShowTheDiv =
+    '$("#theDiv").append("<div class=\\"child\\">a waitFor child</div>");\n' +
+    '$("#theDiv").hide();\n' +
+    'setTimeout(function() {\n' +
+    ' $("#theDiv").show();\n' +
+    '}, arguments[0]);\n';
+
+  var appendChildAndHideTheDiv =
+    '$("#theDiv").append("<div class=\\"child\\">a waitFor child</div>");\n' +
+    'setTimeout(function() {\n' +
+    ' $("#theDiv").hide();\n' +
+    '}, arguments[0]);\n';
+
   var partials = {};
 
   var browser;
@@ -53,10 +66,26 @@ describe('asserters ' + env.ENV_DESC, function() {
       .text().should.become('a waitFor child');
   });
 
+  partials['asserters.isVisible when parentNode is hide and show'] = page;
+  it('asserters.isVisible when parentNode is hide and show', function() {
+    return browser
+      .execute( appendChildHideAndShowTheDiv, [env.BASE_TIME_UNIT] )
+      .waitForElementByCss("#theDiv .child", asserters.isVisible ,2 * env.BASE_TIME_UNIT)
+      .text().should.become('a waitFor child');
+  });
+
   partials['asserters.isHidden'] = page;
   it('asserters.isHidden', function() {
     return browser
       .execute( appendChildAndHide, [env.BASE_TIME_UNIT] )
+      .waitForElementByCss("#theDiv .child", asserters.isHidden ,2 * env.BASE_TIME_UNIT)
+      .text().should.become('');
+  });
+
+  partials['asserters.isHidden when parentNode is hide'] = page;
+  it('asserters.isHidden when parentNode is hide', function() {
+    return browser
+      .execute( appendChildAndHideTheDiv, [env.BASE_TIME_UNIT] )
       .waitForElementByCss("#theDiv .child", asserters.isHidden ,2 * env.BASE_TIME_UNIT)
       .text().should.become('');
   });


### PR DESCRIPTION
Currently `isVisible` asserter is checking if an element's computed style `'display' != 'none'`, which will not work well if an element's parentNode is hidden. Same applies to the `isHidden` asserter.

The fix is to use `isDisplayed` method for both `isVisible` and `isHidden` asserters. `isDisplayed` will actually tell you whether an element is visible or not in the browser. 

The main reason I did this is that sometime I tried to `waitForVisible` an element before clicking it, it gave me false positive when the element was actually not displayed.  
