### PR TITLE
fix url parsing when url passed in as string

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -72,7 +72,7 @@ var parseRemoteWdConfig = function(args) {
   if ((typeof args[0]) === 'object') {
     config = buildConfigUrl( args[0] );
   } else if ((typeof args[0]) === 'string' && (args[0].match(/^https?:\/\//)))  {
-    config = url.parse(args[0]);
+    config = buildConfigUrl(url.parse(args[0]));
   } else {
     config = buildConfigUrl( {
       hostname: args[0],


### PR DESCRIPTION
was struggling to get wd. to connect to a chromedriver process when passing url in as a string, but it was working fine if I passed it through url.parse first. tracked it down to this block which currently omits the call to buildConfigUrl() if the argument is a url string.
