### PR TITLE
Remove 'Key' from Special Keys map

### DIFF
--- a/lib/special-keys.js
+++ b/lib/special-keys.js
@@ -12,7 +12,6 @@ var SPECIAL_KEYS = {
   'Alt': '\uE00A',
   'Pause': '\uE00B',
   'Escape': '\uE00C',
-  'Key': 'Code',
   'Space': '\uE00D',
   'Pageup': '\uE00E',
   'Pagedown': '\uE00F',


### PR DESCRIPTION
'Key' doesn't seem to be a pressable, non-text key :zap:
https://code.google.com/p/selenium/wiki/JsonWireProtocol#/session/:sessionId/element/:id/value
