### PR TITLE
Only use SAUCE_USERNAME and SAUCE_ACCESS_KEY if not specified in the rem...

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -90,7 +90,7 @@ var parseRemoteWdConfig = function(args) {
   // saucelabs automatic config
   if( /saucelabs\.com/.exec(config.hostname) )
   {
-    if(process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY){
+    if(!config.auth && process.env.SAUCE_USERNAME && process.env.SAUCE_ACCESS_KEY){
       config.auth = process.env.SAUCE_USERNAME + ':' + process.env.SAUCE_ACCESS_KEY;
     }
   }

--- a/test/specs/remote-specs.js
+++ b/test/specs/remote-specs.js
@@ -260,6 +260,28 @@ describe("automatic Saucelabs config", function() {
     browser.configUrl.auth.should.equal('zorro:1234-5678');
     done();
   });
+  it("browser should be initialized with indexed parameters username and accessKey", function(done) {
+    var browser;
+    browser = wd.remote('ondemand.saucelabs.com', 80, 'not_zorro', '8765-4321');
+    browser.configUrl.hostname.should.equal('ondemand.saucelabs.com');
+    browser.configUrl.port.should.equal('80');
+    browser.configUrl.pathname.should.equal('/wd/hub');
+    browser.configUrl.auth.should.equal('not_zorro:8765-4321');
+    done();
+  });
+  it("browser should be initialized with named parameters username and accessKey", function(done) {
+    var browser;
+    browser = wd.remote({
+      hostname: 'ondemand.saucelabs.com',
+      port:80,
+      username: 'not_zorro',
+      accessKey: '8765-4321' });
+    browser.configUrl.hostname.should.equal('ondemand.saucelabs.com');
+    browser.configUrl.port.should.equal('80');
+    browser.configUrl.pathname.should.equal('/wd/hub');
+    browser.configUrl.auth.should.equal('not_zorro:8765-4321');
+    done();
+  });
   it("browser should be initialized with url string", function(done) {
     var browser;
     browser = wd.remote('http://ondemand.saucelabs.com/wd/hub');


### PR DESCRIPTION
Was having problems connecting to Sauce when I realized it was using my expired SAUCE_USERNAME and SAUCE_ACCESS_KEY environment variables instead of the username and accessKey I specified in the remote configuration. Added a check to only set the auth options from ENV if they're not already set.
