### PR TITLE
update doubleClick command to allow passing x and y optional offsets 

### DIFF
--- a/lib/element-commands.js
+++ b/lib/element-commands.js
@@ -88,12 +88,17 @@ elementCommands.tap = function (cb) {
 };
 
 /**
- * element.doubleClick(cb) -> cb(err)
- *
+ * element.doubleClick(xoffset, yoffset, cb) -> cb(err)
+ * Before double click moves mouse cursor to element, xoffset and y offset are optional
  * @jsonWire POST /session/:sessionId/doubleclick
  */
-elementCommands.doubleclick = function(cb) {
-  return commands.moveTo.apply(this.browser, [this, function(err) {
+elementCommands.doubleclick = function() {
+  var fargs = utils.varargs(arguments);
+  var cb = fargs.callback,
+      xoffset = fargs.all[0],
+      yoffset = fargs.all[1];
+
+  return commands.moveTo.apply(this.browser, [this, xoffset, yoffset, function(err) {
     if(err) { return cb(err); }
     commands.doubleclick.apply(this.browser, [cb]);
   }.bind(this)]);


### PR DESCRIPTION
I need to be able to move mouse cursor to specified offset before double click, not only to the center of element (it's how it works by default)
