### PR TITLE
use concat, not union to add callback

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -219,7 +219,7 @@ _(commands).each(function(fn, name) {
         if(fargs.callback) { fargs.callback.apply(null, cbArgs); }
       }
     };
-    var args = _.union(fargs.all,[cb]);
+    var args = fargs.all.concat([cb]);
     return fn.apply(this, args);
   };
 });


### PR DESCRIPTION
`_.union` will make each item in the resulting array unique, which I don't think is the intended result. For example, if `fn` was `setWindowSize` which was called with equivalent width/height values, you'd have a problem (one of them would be stripped out of `args`).

I'm not entirely sure what the intention is here and if concat is sufficient, but it seems like union is definitely not what is desired here.
