### PR TITLE
Prevent dropping of non-unique arguments

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -48,7 +48,7 @@ _(elementCommands).each(function(fn, name) {
         fargs.callback.apply(null, cbArgs);
       }
     };
-    var args = _.union(fargs.all,[cb]);
+    var args = fargs.all.concat([cb]);
     return fn.apply(this, args);
   };
 });


### PR DESCRIPTION
Fixes #290

Using _.union caused non-unique arguments to be removed from fargs.all, which could have unexpected consequences if calling methods such as Element#moveTo which take multiple numerical arguments.

I _think_ this _should_ be sufficient to fix, but I always use wd with promise chains and not callbacks, so I'm not intimately familiar with it.
