### PR TITLE
Checking that obj.value is defined

### DIFF
--- a/lib/callbacks.js
+++ b/lib/callbacks.js
@@ -87,11 +87,11 @@ exports.callbackWithData = function(cb, browser) {
       {message:obj.value.message,cause:obj.value}));}
     // we might get a WebElement back as part of executeScript, so let's
     // check to make sure we convert if necessary to element objects
-    if(obj.value !== null && typeof obj.value.ELEMENT !== "undefined") {
+    if(obj.value && typeof obj.value.ELEMENT !== "undefined") {
         obj.value = browser.newElement(obj.value.ELEMENT);
     } else if (Object.prototype.toString.call(obj.value) === "[object Array]") {
         for (var i = 0; i < obj.value.length; i++) {
-            if (obj.value[i] !== null && typeof obj.value[i].ELEMENT !== "undefined") {
+            if (obj.value[i] && typeof obj.value[i].ELEMENT !== "undefined") {
                 obj.value[i] = browser.newElement(obj.value[i].ELEMENT);
             }
         }


### PR DESCRIPTION
And not null because in some cases it can be undefined which will trigger an error.

```
  Uncaught TypeError: Cannot read property 'ELEMENT' of undefined
      at c:\Users\ricki.hastings\Projects\betfred-mobi-functional-tests\node_modules\wd\lib\callbacks.js:90:46
      at c:\Users\ricki.hastings\Projects\betfred-mobi-functional-tests\node_modules\wd\lib\callbacks.js:76:7
      at c:\Users\ricki.hastings\Projects\betfred-mobi-functional-tests\node_modules\wd\lib\webdriver.js:178:5
      at Request._callback (c:\Users\ricki.hastings\Projects\betfred-mobi-functional-tests\node_modules\wd\lib\http-utils.js:62:7)
      at Request.self.callback (c:\Users\ricki.hastings\Projects\betfred-mobi-functional-tests\node_modules\wd\node_modules\request\request.js:122:22)
      at Request.EventEmitter.emit (events.js:98:17)
      at Request.<anonymous> (c:\Users\ricki.hastings\Projects\betfred-mobi-functional-tests\node_modules\wd\node_modules\request\request.js:888:14)
      at Request.EventEmitter.emit (events.js:117:20)
      at IncomingMessage.<anonymous> (c:\Users\ricki.hastings\Projects\betfred-mobi-functional-tests\node_modules\wd\node_modules\request\request.js:839:12)
      at IncomingMessage.EventEmitter.emit (events.js:117:20)
      at _stream_readable.js:919:16
      at process._tickCallback (node.js:419:13)
```

I'm only occasionally able to reproduce this, I think it varies on environments. I'm testing on real android devices via browserstack using `realMobile: true` capability.  The reason for the error is simply that `obj.value` is undefined and not null.
