### PR TITLE
Add device.openNotifications method

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -2887,4 +2887,18 @@ commands.getNetworkConnection = function() {
   });
 };
 
+/**
+ * openNotifications(cb) -> cb(err)
+ *
+ * @jsonWire GET /session/:sessionId/appium/device/open_notifications
+ */
+commands.openNotifications = function() {
+  var cb = findCallback(arguments);
+  this._jsonWireCall({
+    method: 'GET'
+    , relPath: '/appium/device/open_notifications'
+    , cb: simpleCallback(cb, this)
+  });
+}
+
 module.exports = commands;

--- a/test/specs/mjson-specs.js
+++ b/test/specs/mjson-specs.js
@@ -904,6 +904,18 @@ describe("mjson tests", function() {
           .nodeify(done);
       });
 
+      it("openNotifications", function(done) {
+        nock.cleanAll();
+        server
+          .get('/session/1234/appium/device/open_notifications')
+          .reply(200, {
+            status: 0,
+            sessionId: '1234'
+          });
+        browser
+          .openNotifications()
+          .nodeify(done);
+      });
     });
   });
 


### PR DESCRIPTION
Support for new endpoint to open notifications shade on Android.
