### PR TITLE
Change method to POST for openNotifications

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -2890,12 +2890,12 @@ commands.getNetworkConnection = function() {
 /**
  * openNotifications(cb) -> cb(err)
  *
- * @jsonWire GET /session/:sessionId/appium/device/open_notifications
+ * @jsonWire POST /session/:sessionId/appium/device/open_notifications
  */
 commands.openNotifications = function() {
   var cb = findCallback(arguments);
   this._jsonWireCall({
-    method: 'GET'
+    method: 'POST'
     , relPath: '/appium/device/open_notifications'
     , cb: simpleCallback(cb, this)
   });

--- a/test/specs/mjson-specs.js
+++ b/test/specs/mjson-specs.js
@@ -907,7 +907,7 @@ describe("mjson tests", function() {
       it("openNotifications", function(done) {
         nock.cleanAll();
         server
-          .get('/session/1234/appium/device/open_notifications')
+          .post('/session/1234/appium/device/open_notifications')
           .reply(200, {
             status: 0,
             sessionId: '1234'


### PR DESCRIPTION
I hate to do this to you, but it's been decided that `/wd/hub/session/:sessionId?/appium/device/open_notifications` should be a `POST` endpoint.
