### PR TITLE
Retry requests also on ESOCKETTIMEOUT

### DIFF
--- a/lib/http-utils.js
+++ b/lib/http-utils.js
@@ -61,12 +61,18 @@ exports.newHttpOpts = function(method, httpConfig) {
   return opts;
 };
 
+var shouldRetryOn = function(err) {
+    return err.code === 'ECONNRESET' || 
+        err.code === 'ETIMEDOUT' ||
+        err.code === 'ESOCKETTIMEDOUT';
+};
+
 var requestWithRetry = function(httpOpts, httpConfig, emit, cb, attempts) {
   request(httpOpts, function(err, res, data) {
     if(!attempts) { attempts = 1; }
     if( httpConfig.retries >= 0 &&
       (httpConfig.retries === 0 || (attempts -1) <= httpConfig.retries) &&
-      err && (err.code === 'ECONNRESET' || err.code === 'ETIMEDOUT')) {
+      err && (shouldRetryOn(err))) {
       emit('connection', err.code , 'Lost http connection retrying in ' + httpConfig.retryDelay + ' ms.', err);
       setTimeout(function() {
         requestWithRetry(httpOpts, httpConfig, emit, cb, attempts + 1 );


### PR DESCRIPTION
`request` module sets two timeouts:
- timeout for the whole request (fails with ETIMEOUT, handled by `wd`);
- socket timeout, used when response received header but failed to
  receive data. This one fails with ESOCKETTIMEOUT and not handled
  by `wd`, so retries does not occur.

This PR fixes the problem.
