### PR TITLE
Fix Selenium errors handling

### DIFF
--- a/lib/callbacks.js
+++ b/lib/callbacks.js
@@ -27,6 +27,9 @@ exports.simpleCallback = function(cb) {
           if(jsonwireError) {
             errorMessage += ", " + jsonwireError.summary + " - " + jsonwireError.detail;
           }
+          if(jsonWireRes.value && jsonWireRes.value.message) {
+            errorMessage += " Selenium error: " + jsonWireRes.value.message;
+          }
           var error = newError(
             { message: errorMessage
               , status:jsonWireRes.status
@@ -65,6 +68,9 @@ var callbackWithDataBase = function(cb) {
       var errorMessage = 'Error response status: ' + obj.status + ", " +alertText;
       if(jsonwireError) {
         errorMessage += ", " + jsonwireError.summary + " - " + jsonwireError.detail;
+      }
+      if(obj.value && obj.value.message) {
+        errorMessage += " Selenium error: " + obj.value.message;
       }
       var error = newError(
         { message: errorMessage


### PR DESCRIPTION
Do not check for `sessionId` in Selenium responses, because some errors does not have it. Also pass Selenium error message to the callback error.

For example:

``` js
{
  "status":13,
  "value":{
    "message":"Session [f90c948b-ddf0-46d2-b0f0-8852dd26802f] was terminated due to BROWSER_TIMEOUT",
    "class":"org.openqa.grid.common.exception.GridException",
    "stackTrace":[
      {
        "fileName":"ActiveTestSessions.java",
        "lineNumber":104,
        "className":"org.openqa.grid.internal.ActiveTestSessions",
        "methodName":"getExistingSession"
      },
      {
        "fileName":"Registry.java",
        "lineNumber":423,
        "className":"org.openqa.grid.internal.Registry",
        "methodName":"getExistingSession"
      },
      {
        "fileName":"RequestHandler.java",
        "lineNumber":235,
        "className":"org.openqa.grid.web.servlet.handler.RequestHandler",
        "methodName":"getSession"
      },
      {
        "fileName":"RequestHandler.java",
        "lineNumber":117,
        "className":"org.openqa.grid.web.servlet.handler.RequestHandler",
        "methodName":"process"
      },
      {
        "fileName":"DriverServlet.java",
        "lineNumber":84,
        "className":"org.openqa.grid.web.servlet.DriverServlet",
        "methodName":"process"
      },
      {
        "fileName":"DriverServlet.java",
        "lineNumber":74,
        "className":"org.openqa.grid.web.servlet.DriverServlet",
        "methodName":"doDelete"
      },
      {
        "fileName":"HttpServlet.java",
        "lineNumber":733,
        "className":"javax.servlet.http.HttpServlet",
        "methodName":"service"
      },
      {
        "fileName":"HttpServlet.java",
        "lineNumber":820,
        "className":"javax.servlet.http.HttpServlet",
        "methodName":"service"
      },
      {
        "fileName":"ServletHolder.java",
        "lineNumber":565,
        "className":"org.seleniumhq.jetty7.servlet.ServletHolder",
        "methodName":"handle"
      },
      {
        "fileName":"ServletHandler.java",
        "lineNumber":479,
        "className":"org.seleniumhq.jetty7.servlet.ServletHandler",
        "methodName":"doHandle"
      },
      {
        "fileName":"SessionHandler.java",
        "lineNumber":225,
        "className":"org.seleniumhq.jetty7.server.session.SessionHandler",
        "methodName":"doHandle"
      },
      {
        "fileName":"ContextHandler.java",
        "lineNumber":1031,
        "className":"org.seleniumhq.jetty7.server.handler.ContextHandler",
        "methodName":"doHandle"
      },
      {
        "fileName":"ServletHandler.java",
        "lineNumber":406,
        "className":"org.seleniumhq.jetty7.servlet.ServletHandler",
        "methodName":"doScope"
      },
      {
        "fileName":"SessionHandler.java",
        "lineNumber":186,
        "className":"org.seleniumhq.jetty7.server.session.SessionHandler",
        "methodName":"doScope"
      },
      {
        "fileName":"ContextHandler.java",
        "lineNumber":965,
        "className":"org.seleniumhq.jetty7.server.handler.ContextHandler",
        "methodName":"doScope"
      },
      {
        "fileName":"ScopedHandler.java",
        "lineNumber":117,
        "className":"org.seleniumhq.jetty7.server.handler.ScopedHandler",
        "methodName":"handle"
      },
      {
        "fileName":"HandlerWrapper.java",
        "lineNumber":111,
        "className":"org.seleniumhq.jetty7.server.handler.HandlerWrapper",
        "methodName":"handle"
      },
      {
        "fileName":"Server.java",
        "lineNumber":345,
        "className":"org.seleniumhq.jetty7.server.Server",
        "methodName":"handle"
      },
      {
        "fileName":"AbstractHttpConnection.java",
        "lineNumber":452,
        "className":"org.seleniumhq.jetty7.server.AbstractHttpConnection",
        "methodName":"handleRequest"
      },
      {
        "fileName":"BlockingHttpConnection.java",
        "lineNumber":47,
        "className":"org.seleniumhq.jetty7.server.BlockingHttpConnection",
        "methodName":"handleRequest"
      },
      {
        "fileName":"AbstractHttpConnection.java",
        "lineNumber":884,
        "className":"org.seleniumhq.jetty7.server.AbstractHttpConnection",
        "methodName":"headerComplete"
      },
      {
        "fileName":"AbstractHttpConnection.java",
        "lineNumber":938,
        "className":"org.seleniumhq.jetty7.server.AbstractHttpConnection$RequestHandler",
        "methodName":"headerComplete"
      },
      {
        "fileName":"HttpParser.java",
        "lineNumber":634,
        "className":"org.seleniumhq.jetty7.http.HttpParser",
        "methodName":"parseNext"
      },
      {
        "fileName":"HttpParser.java",
        "lineNumber":230,
        "className":"org.seleniumhq.jetty7.http.HttpParser",
        "methodName":"parseAvailable"
      },
      {
        "fileName":"BlockingHttpConnection.java",
        "lineNumber":66,
        "className":"org.seleniumhq.jetty7.server.BlockingHttpConnection",
        "methodName":"handle"
      },
      {
        "fileName":"SocketConnector.java",
        "lineNumber":254,
        "className":"org.seleniumhq.jetty7.server.bio.SocketConnector$ConnectorEndPoint",
        "methodName":"run"
      },
      {
        "fileName":"QueuedThreadPool.java",
        "lineNumber":599,
        "className":"org.seleniumhq.jetty7.util.thread.QueuedThreadPool",
        "methodName":"runJob"
      },
      {
        "fileName":"QueuedThreadPool.java",
        "lineNumber":534,
        "className":"org.seleniumhq.jetty7.util.thread.QueuedThreadPool$3",
        "methodName":"run"
      },
      {
        "fileName":"Thread.java",
        "lineNumber":744,
        "className":"java.lang.Thread",
        "methodName":"run"
      }
    ]
  }
}
```
