### PR TITLE
Added replaceKeys method

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1726,6 +1726,23 @@ commands.type = function(element, keys) {
   });
 };
 
+commands.replace = function(element, keys) {
+  var cb = findCallback(arguments);
+  if (!(keys instanceof Array)) {keys = [keys];}
+  // ensure all keystrokes are strings to conform to JSONWP
+  _.each(keys, function(key, idx) {
+    if (typeof key !== "string") {
+      keys[idx] = key.toString();
+    }
+  });
+  this._jsonWireCall({
+    method: 'POST'
+    , relPath: '/appium/element/' + element + '/replace_value'
+    , data: {value: keys}
+    , cb: simpleCallback(cb)
+  });
+};
+
 /**
  * submit(element, cb) -> cb(err)
  * Submit a `FORM` element.

--- a/lib/element-commands.js
+++ b/lib/element-commands.js
@@ -70,6 +70,25 @@ elementCommands.sendKeys = function (keys, cb) {
 };
 
 /**
+ * Equivalent to the python sendKeys binding, but replaces texts instead of keeping original. Upload file if
+ * a local file is detected, otherwise behaves like type.
+ * element.replaceKeys(keys, cb) -> cb(err)
+ */
+
+elementCommands.replaceKeys = function (keys, cb) {
+  var _this = this;
+  if (!(keys instanceof Array)) {keys = [keys];}
+
+  // ensure all keystrokes are strings to conform to JSONWP
+  _.each(keys, function(key, idx) {
+    if (typeof key !== "string") {
+      keys[idx] = key.toString();
+    }
+  });
+  commands.replace.apply(_this.browser, [_this, keys, cb]);
+}
+
+/**
  * element.click(cb) -> cb(err)
  *
  * @jsonWire POST /session/:sessionId/element/:id/click


### PR DESCRIPTION
Added replace and replaceKeys functions for the "replace" parameter that I'm going to add in setText.java.

Was going to do this all in element-commands.js, but it looks like I would need to add 12 dependencies and an init function, so I thought it may be cleaner to keep it in two files. If that isn't as neat I can just move them.

This has been tested in conjunction with the "replace" param and works without any errors.
