### PR TITLE
Added api to launch arbitrary Android activities

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -1323,6 +1323,17 @@ toggleData(cb) -&gt; cb(err)<br>
 </tr>
 <tr>
 <td style="border: 1px solid #ccc; padding: 5px;">
+POST <a href="http://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/session/:sessionId/appium/device/start_activity">/session/:sessionId/appium/device/start_activity</a><br>
+Start an Android activity (mjsonWire).
+</td>
+<td style="border: 1px solid #ccc; padding: 5px;">
+startActivity(options, cb) -&gt; cb(err)<br>
+Start an arbitrary Android activity during a session. The 'options' parameter should<br>
+implement the interface {appPackage, appActivity, [appWaitPackage], [appWaitActivity]}.<br>
+</td>
+</tr>
+<tr>
+<td style="border: 1px solid #ccc; padding: 5px;">
 POST <a href="http://code.google.com/p/selenium/wiki/JsonWireProtocol#POST_/session/:sessionId/appium/app/launch">/session/:sessionId/appium/app/launch</a><br>
 Launch app (mjsonWire).
 </td>
@@ -1697,7 +1708,7 @@ extra
 <td style="border: 1px solid #ccc; padding: 5px;">
 Equivalent to the python sendKeys binding, but replaces texts instead of keeping original. Upload file if<br>
 a local file is detected, otherwise behaves like type.<br>
-element.replaceKeys(keys, cb) -&gt; cb(err)<br>
+element.setText(keys, cb) -&gt; cb(err)<br>
 </td>
 </tr>
 <tr>

--- a/doc/jsonwire-full.json
+++ b/doc/jsonwire-full.json
@@ -114,6 +114,7 @@
   "POST /session/:sessionId/appium/device/toggle_wifi": "Toggle wifi (mjsonWire).",
   "POST /session/:sessionId/appium/device/toggle_location_services": "Toggle location services (mjsonWire).",
   "POST /session/:sessionId/appium/device/toggle_data": "Toggle data (mjsonWire).",
+  "POST /session/:sessionId/appium/device/start_activity": "Start an Android activity (mjsonWire).",
   "POST /session/:sessionId/appium/app/launch": "Launch app (mjsonWire).",
   "POST /session/:sessionId/appium/app/close": "Close app (mjsonWire).",
   "POST /session/:sessionId/appium/app/reset": "Reset app (mjsonWire).",

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -2883,6 +2883,25 @@ commands.setImmediateValueInApp = function(element, value) {
 };
 
 /**
+ * startActivity(options, cb) -> cb(err)
+ * Start an arbitrary Android activity during a session. The 'options' parameter should
+ * implement the interface {appPackage, appActivity, [appWaitPackage], [appWaitActivity]}.
+ *
+ * @jsonWire POST /session/:sessionId/appium/device/start_activity
+ */
+commands.startActivity = function(options) {
+  var fargs = utils.varargs(arguments);
+  var cb = fargs.callback,
+    options = fargs.all[0];
+  this._jsonWireCall({
+    method: 'POST'
+    , relPath: '/appium/device/start_activity'
+    , data: options
+    , cb: simpleCallback(cb)
+  });
+};
+
+/**
  * setImmediateValue(element, value, cb) -> cb(err)
  *
  * @jsonWire POST /session/:sessionId/appium/element/:elementId?/value


### PR DESCRIPTION
This change is required for compatibility with changes in Appium's API - #2969 (https://github.com/appium/appium/issues/2969).

I notice the "setText" change is unrelated.  I left it, however, in the case that it's updating something you want to keep.
