### PR TITLE
Basic Authorization (header) should be provided across requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ to install and start a selenium server.
   - Bernard Kobos ([bernii](https://github.com/bernii))
   - Jason Carr ([maudineormsby](https://github.com/maudineormsby))
   - Matti Schneider ([MattiSG](https://github.com/MattiSG))
+  - Hernan Lopes ([hernan604](https://github.com/hernan604))
 
 ## License
 

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -23,7 +23,6 @@ var Webdriver = module.exports = function(configUrl) {
   this.sauceRestRoot = "https://saucelabs.com/rest/v1";
   // config url without auth
   this.noAuthConfigUrl = url.parse(url.format(this.configUrl));
-  delete this.noAuthConfigUrl.auth;
 
   this.defaultCapabilities = {
     browserName: 'firefox'


### PR DESCRIPTION
Hi, 

While using WD, i noticed it only sent Basic authorization credentials header on the first request (when it requests a session id).
There is a possibility to use session id to relate that with basic authorization, but i think the basic autorization header should be sent accross requests just like other drivers does it.

Please accept the merge if agreed.

Thanks,

Hernan Lopes