### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,7 @@
     "type": "git",
     "url": "https://github.com/admc/wd.git"
   },
-  "licenses": [
-    {
-      "type": "Apache",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
-    }
-  ],
+  "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/admc/wd/issues"
   },


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/