### PR TITLE
Emit https://saucelabs.com/jobs/SESSIONID link when running on Saucelabs.

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -20,6 +20,7 @@ var Webdriver = module.exports = function(configUrl) {
   EventEmitter.call( this );
   this.sessionID = null;
   this.configUrl = configUrl;
+  this.sauceTestPageRoot = "https://saucelabs.com/jobs";
   this.sauceRestRoot = "https://saucelabs.com/rest/v1";
   // config url without auth
   this.noAuthConfigUrl = url.parse(url.format(this.configUrl));
@@ -121,7 +122,11 @@ Webdriver.prototype._init = function() {
     }
 
     if (_this.sessionID) {
-      _this.emit('status', '\nDriving the web on session: ' + _this.sessionID + '\n');
+      if (/saucelabs\.com/.exec(url.hostname)) {
+        _this.emit('status', '\nDriving the web on session: ' + _this.sauceTestPageRoot + '/' + _this.sessionID + '\n');
+      } else {
+        _this.emit('status', '\nDriving the web on session: ' + _this.sessionID + '\n');
+      }
       if (cb) { cb(null, _this.sessionID, resData); }
     } else {
       data = strip(data);


### PR DESCRIPTION
E.g.
```
Driving the web on session: https://saucelabs.com/tests/6767a03ebcc348e386b568ddc56e99b8
```
Handy because you can click while it still runs, and for cross-referencing later (e.g. Travis log->Saucelabs).

Actually I've never used wd with anything other then Saucelabs, hope I got the condition right...