### PR TITLE
Wrap touch action array in object

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1563,7 +1563,7 @@ commands.performTouchAction = function () {
     _this._jsonWireCall({
       method: 'POST',
       relPath: '/touch/perform',
-      data: touchAction.toJSON(),
+      data: {actions: touchAction.toJSON()},
       cb: callbackWithData(cb, this)
     });
   } catch (err) {
@@ -2599,7 +2599,7 @@ commands.hideDeviceKeyboard = function() {
       data = fargs.all[0];
       break;
     default:
-      data= null; 
+      data= null;
   }
   this._jsonWireCall({
     method: 'POST'

--- a/test/specs/mjson-specs.js
+++ b/test/specs/mjson-specs.js
@@ -258,10 +258,10 @@ describe("mjson tests", function() {
               sessionId: '1234',
               value: {ELEMENT: '0'},
             })
-            .post('/session/1234/touch/perform', [
+            .post('/session/1234/touch/perform', {"actions": [
               {"action":"press","options":{x: 100, y: 5}},
               {"action":"release","options":{}}
-            ])
+            ]})
             .times(2)
             .reply(200, {
               status: 0,
@@ -1007,7 +1007,7 @@ describe("mjson tests", function() {
           sessionId: '1234',
           value: {ELEMENT: '0'},
         })
-        .post('/session/1234/touch/perform', [{"action":"tap","options":{}}])
+        .post('/session/1234/touch/perform', {"actions": [{"action":"tap","options":{}}]})
         .times(2)
         .reply(200, {
           status: 0,


### PR DESCRIPTION
Rather than sending a plain array of actions, send an object with the array as an `actions` property. Without this change touch actions do not work on Sauce Labs.

```js
{
    "actions": [
        {"action":"press","options":{x: 100, y: 5}},
        {"action":"release","options":{}}
    ]
}
```

rather than

```js
[
    {"action":"press","options":{x: 100, y: 5}},
    {"action":"release","options":{}}
]
```