### PR TITLE
Add getDeviceTime method

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -3089,4 +3089,18 @@ commands.activeIMEEngine = function () {
   });
 };
 
+/**
+ * getDeviceTime(cb) -> cb(err, deviceTime)
+ *
+ * @jsonWire GET /session/:sessionId/appium/device/system_time
+ */
+commands.getDeviceTime = function () {
+  var cb = findCallback(arguments);
+  this._jsonWireCall({
+    method: 'GET'
+    , relPath: '/appium/device/system_time'
+    , cb: callbackWithData(cb, this)
+  });
+};
+
 module.exports = commands;

--- a/test/specs/mjson-specs.js
+++ b/test/specs/mjson-specs.js
@@ -985,6 +985,19 @@ describe("mjson tests", function() {
           .activeIMEEngine()
           .nodeify(done);
       });
+
+      it("getDeviceTime", function (done) {
+        nock.cleanAll();
+        server
+          .get('/session/1234/appium/device/system_time')
+          .reply(200, {
+            status: 0,
+            sessionId: '1234'
+          });
+        browser
+          .getDeviceTime()
+          .nodeify(done);
+      });
     });
   });
 


### PR DESCRIPTION
Appium has added a method to get the time and date off of the device (https://github.com/appium/node-mobile-json-wire-protocol/issues/40). Add the method to access that endpoint.