### PR TITLE
Test examples for BrowserStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ node lib/bin.js shell
 Then within the shell:
 ```
 ): wd shell
-> x = wd.remote() or wd.remote("ondemand.saucelabs.com", 80, "username", "apikey")
+> x = wd.remote() or wd.remote("ondemand.saucelabs.com", 80, "username", "apikey") or wd.remote("hub.browserstack.com", 80, "username", "apikey")
 
 > x.init() or x.init({desired capabilities override})
 > x.get("http://www.url.com")
@@ -208,6 +208,8 @@ var browser = wd.remote();
 var browser = wd.remote('localhost');
 // or
 var browser = wd.remote('localhost', 8888);
+// or
+var browser = wd.remote("hub.browserstack.com", 80, "username", "apikey");
 // or
 var browser = wd.remote("ondemand.saucelabs.com", 80, "username", "apikey");
 ```
@@ -247,6 +249,8 @@ var browser = wd.remote({
 ```js
 var browser = wd.remote('http://localhost:4444/wd/hub');
 // or
+var browser = wd.remote('http://user:apiKey@hub.browserstack.com/wd/hub');
+// or
 var browser = wd.remote('http://user:apiKey@ondemand.saucelabs.com/wd/hub');
 ```
 
@@ -257,6 +261,8 @@ var browser = wd.remote('http://user:apiKey@ondemand.saucelabs.com/wd/hub');
 ```js
 var url = require('url');
 var browser = wd.remote(url.parse('http://localhost:4444/wd/hub'));
+// or
+var browser = wd.remote(url.parse('http://user:apiKey@hub.browserstack.com:80/wd/hub'));
 // or
 var browser = wd.remote(url.parse('http://user:apiKey@ondemand.saucelabs.com:80/wd/hub'));
 ```
@@ -529,7 +535,7 @@ Sauce Labs cloud.
 
 ### Appium
 
-Android and iOS work locally and on [Sauce Labs](https://saucelabs.com/platforms/appium).
+Android and iOS work locally and on [Sauce Labs](https://saucelabs.com/platforms/appium) or [BrowserStack](https://www.browserstack.com/automate).
 
 ## Run the tests!
 

--- a/examples/async/browserstack.ie.js
+++ b/examples/async/browserstack.ie.js
@@ -1,0 +1,53 @@
+var username = process.env.BROWSERSTACK_USERNAME || "BROWSERSTACK_USERNAME";
+var accessKey = process.env.BROWSERSTACK_ACCESS_KEY || "BROWSERSTACK_ACCESS_KEY";
+
+require('colors');
+var chai = require('chai');
+chai.should();
+
+var wd;
+try {
+  wd = require('wd');
+} catch( err ) {
+  wd = require('../../lib/main');
+}
+
+var browser = wd.remote("hub.browserstack.com", 80, username, accessKey);
+
+// optional extra logging
+browser.on('status', function(info) {
+  console.log(info.cyan);
+});
+browser.on('command', function(eventType, command, response) {
+  console.log(' > ' + eventType.cyan, command, (response || '').grey);
+});
+browser.on('http', function(meth, path, data) {
+  console.log(' > ' + meth.magenta, path, (data || '').grey);
+});
+
+var desired = {
+  os: 'Windows',
+  os_version: '10',
+  browser: 'ie',
+  browser_version: '',
+  project: "examples",
+  name: "This is an example async test",
+  build: "WD BrowserStack Sample Test"
+};
+
+browser.init(desired, function() {
+  browser.get("http://admc.io/wd/test-pages/guinea-pig.html", function() {
+    browser.title(function(err, title) {
+      title.should.include('WD');
+      browser.elementById('i am a link', function(err, el) {
+        browser.clickElement(el, function() {
+          /* jshint evil: true */
+          browser.eval("window.location.href", function(err, href) {
+            href.should.include('guinea-pig2');
+            browser.quit();
+          });
+        });
+      });
+    });
+  });
+});

--- a/examples/async/browserstack.js
+++ b/examples/async/browserstack.js
@@ -1,0 +1,50 @@
+var username = process.env.BROWSERSTACK_USERNAME || "BROWSERSTACK_USERNAME";
+var accessKey = process.env.BROWSERSTACK_ACCESS_KEY || "BROWSERSTACK_ACCESS_KEY";
+
+require('colors');
+var chai = require('chai');
+chai.should();
+
+var wd;
+try {
+  wd = require('wd');
+} catch( err ) {
+  wd = require('../../lib/main');
+}
+
+var browser = wd.remote("hub.browserstack.com", 80, username, accessKey);
+
+// optional extra logging
+browser.on('status', function(info) {
+  console.log(info.cyan);
+});
+browser.on('command', function(eventType, command, response) {
+  console.log(' > ' + eventType.cyan, command, (response || '').grey);
+});
+browser.on('http', function(meth, path, data) {
+  console.log(' > ' + meth.magenta, path, (data || '').grey);
+});
+
+var desired = {
+  platform: 'MAC',
+  project: "examples",
+  name: "This is an example async test",
+  build: "WD BrowserStack Sample Test"
+};
+
+browser.init(desired, function() {
+  browser.get("http://admc.io/wd/test-pages/guinea-pig.html", function() {
+    browser.title(function(err, title) {
+      title.should.include('WD');
+      browser.elementById('i am a link', function(err, el) {
+        browser.clickElement(el, function() {
+          /* jshint evil: true */
+          browser.eval("window.location.href", function(err, href) {
+            href.should.include('guinea-pig2');
+            browser.quit();
+          });
+        });
+      });
+    });
+  });
+});

--- a/examples/promise/browserstack.ie.js
+++ b/examples/promise/browserstack.ie.js
@@ -1,0 +1,49 @@
+var username = process.env.BROWSERSTACK_USERNAME || "BROWSERSTACK_USERNAME";
+var accessKey = process.env.BROWSERSTACK_ACCESS_KEY || "BROWSERSTACK_ACCESS_KEY";
+
+require('colors');
+var chai = require("chai");
+var chaiAsPromised = require("chai-as-promised");
+
+chai.use(chaiAsPromised);
+chai.should();
+
+var wd = require('wd');
+
+// enables chai assertion chaining
+chaiAsPromised.transferPromiseness = wd.transferPromiseness;
+
+var browser = wd.promiseChainRemote("hub.browserstack.com", 80, username, accessKey);
+
+// optional extra logging
+browser.on('status', function(info) {
+  console.log(info.cyan);
+});
+browser.on('command', function(eventType, command, response) {
+  console.log(' > ' + eventType.cyan, command, (response || '').grey);
+});
+browser.on('http', function(meth, path, data) {
+  console.log(' > ' + meth.magenta, path, (data || '').grey);
+});
+
+var desired = {
+  os: 'Windows',
+  os_version: '',
+  browser: 'ie',
+  browser_version: '',
+  project: "examples",
+  name: "This is an example test with promises",
+  build: "WD BrowserStack Sample Test"
+};
+
+browser
+  .init(desired)
+  .get("http://admc.io/wd/test-pages/guinea-pig.html")
+  .title()
+    .should.become('WD Tests')
+  .elementById('i am a link')
+  .click()
+  .eval("window.location.href")
+    .should.eventually.include('guinea-pig2')
+  .fin(function() { return browser.quit(); })
+  .done();

--- a/examples/promise/browserstack.js
+++ b/examples/promise/browserstack.js
@@ -1,0 +1,46 @@
+var username = process.env.BROWSERSTACK_USERNAME || "BROWSERSTACK_USERNAME";
+var accessKey = process.env.BROWSERSTACK_ACCESS_KEY || "BROWSERSTACK_ACCESS_KEY";
+
+require('colors');
+var chai = require("chai");
+var chaiAsPromised = require("chai-as-promised");
+
+chai.use(chaiAsPromised);
+chai.should();
+
+var wd = require('wd');
+
+// enables chai assertion chaining
+chaiAsPromised.transferPromiseness = wd.transferPromiseness;
+
+var browser = wd.promiseChainRemote("hub.browserstack.com", 80, username, accessKey);
+
+// optional extra logging
+browser.on('status', function(info) {
+  console.log(info.cyan);
+});
+browser.on('command', function(eventType, command, response) {
+  console.log(' > ' + eventType.cyan, command, (response || '').grey);
+});
+browser.on('http', function(meth, path, data) {
+  console.log(' > ' + meth.magenta, path, (data || '').grey);
+});
+
+var desired = {
+  platform: "MAC",
+  project: "examples",
+  name: "This is an example test with promises",
+  build: "WD BrowserStack Sample Test"
+};
+
+browser
+  .init(desired)
+  .get("http://admc.io/wd/test-pages/guinea-pig.html")
+  .title()
+    .should.become('WD Tests')
+  .elementById('i am a link')
+  .click()
+  .eval("window.location.href")
+    .should.eventually.include('guinea-pig2')
+  .fin(function() { return browser.quit(); })
+  .done();


### PR DESCRIPTION
- Added examples to test on BrowserStack using wd (Async and with Promises).
- Changed README to add example to use constructor `wd.remote` for BrowserStack