### PR TITLE
Upgrade archiver

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "archiver": "~0.14.0",
+    "archiver": "~1.0.0",
     "async": "~1.0.0",
     "lodash": "~3.9.3",
     "q": "~1.4.1",


### PR DESCRIPTION
this upgrade to archiver is due to the vulnerability in minimatch
https://nodesecurity.io/advisories/118
which is imported by glob and then archive

this is automatically flagged by the node security project cli
in my setup. Your library eventually gets called into mocha by karma sauce launcher.