### PR TITLE
Remove bdd_with_opts dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 - [Site](http://admc.io/wd/)
 - [Mailing List](https://groups.google.com/forum/#!forum/wdjs)
 
+This library is designed to be a maleable implementation of the webdriver protocol in Node, exposing functionality via a number of programming paradigms. If you are looking for a more polished, opinionated and active library - I would suggest [webdriver.io](http://webdriver.io/).
+
 ## Release Notes
 [here](https://github.com/admc/wd/blob/master/doc/release-notes.md)
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@ function buildMochaOpts(opts) {
 
   var mochaOpts = {
     flags: {
-      u: 'bdd-with-opts',
+      u: 'bdd',
       R: 'spec',
       c: true
     },

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -3089,4 +3089,18 @@ commands.activeIMEEngine = function () {
   });
 };
 
+/**
+ * getDeviceTime(cb) -> cb(err, deviceTime)
+ *
+ * @jsonWire GET /session/:sessionId/appium/device/system_time
+ */
+commands.getDeviceTime = function () {
+  var cb = findCallback(arguments);
+  this._jsonWireCall({
+    method: 'GET'
+    , relPath: '/appium/device/system_time'
+    , cb: callbackWithData(cb, this)
+  });
+};
+
 module.exports = commands;

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -430,7 +430,7 @@ commands.setGeoLocation = function(lat, lon, alt) {
 /**
  * scroll(xOffset, yOffset, cb) -> cb(err)
  *
- * @jsonWire POST /session/:sessionId/log
+ * @jsonWire POST /session/:sessionId/touch/scroll
  */
 commands.scroll = function(xOffset, yOffset) {
   var cb = findCallback(arguments);

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -20,6 +20,7 @@ var Webdriver = module.exports = function(configUrl) {
   EventEmitter.call( this );
   this.sessionID = null;
   this.configUrl = configUrl;
+  this.sauceTestPageRoot = "https://saucelabs.com/jobs";
   this.sauceRestRoot = "https://saucelabs.com/rest/v1";
   // config url without auth
   this.noAuthConfigUrl = url.parse(url.format(this.configUrl));
@@ -121,7 +122,11 @@ Webdriver.prototype._init = function() {
     }
 
     if (_this.sessionID) {
-      _this.emit('status', '\nDriving the web on session: ' + _this.sessionID + '\n');
+      if (/saucelabs\.com/.exec(url.hostname)) {
+        _this.emit('status', '\nDriving the web on session: ' + _this.sauceTestPageRoot + '/' + _this.sessionID + '\n');
+      } else {
+        _this.emit('status', '\nDriving the web on session: ' + _this.sessionID + '\n');
+      }
       if (cb) { cb(null, _this.sessionID, resData); }
     } else {
       data = strip(data);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "webdriverjs",
     "selenium"
   ],
-  "version": "0.3.12",
+  "version": "0.4.0",
   "author": "Adam Christian <adam.christian@gmail.com>",
   "contributors": [
     "Ruben Daniels (https://github.com/javruben)",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "vargs": "~0.1.0"
   },
   "devDependencies": {
-    "bdd-with-opts": "~1.0.0",
     "chai": "~2.3.0",
     "chai-as-promised": "~5.0.0",
     "colors": "~1.1.0",

--- a/test/helpers/skip.js
+++ b/test/helpers/skip.js
@@ -19,6 +19,20 @@ GLOBAL.skip = function () {
     var re = new RegExp( '^' + skipConfig + '$','i');
     return (env.BROWSER || "").match(re) || (cat||"").match(re);
   });
-  return found ? {pending: true} : {};
+  if(found) {
+    return function(testFunction) {
+      return function() {
+        if (this.skip) {  // Inside it() test case.
+          this.skip();
+        } else {  // Inside describe() test group.
+          before(function() {
+            this.skip();
+          });
+          testFunction.call(this);
+        }
+      };
+    }
+  } else {
+    return _.identity;
+  }
 };
-

--- a/test/midway/api-el-specs.js
+++ b/test/midway/api-el-specs.js
@@ -10,10 +10,10 @@ describe('api-el ' + env.ENV_DESC, function() {
     '<div name="theDiv">Hello World!</div>';
   it('browser.element', function() {
     var seq = [
-      function() { 
+      function() {
         return browser.element("name", "theDiv").should.eventually.exist; },
-      function() { 
-        return browser.element("name", "theDiv2").should.be.rejectedWith(/status: 7/); },      
+      function() {
+        return browser.element("name", "theDiv2").should.be.rejectedWith(/status: 7/); },
     ];
     return seq.reduce(Q.when, new Q());
     // return Q.all([
@@ -48,7 +48,7 @@ describe('api-el ' + env.ENV_DESC, function() {
 
   partials['browser.waitForElement'] =
     '<div id="theDiv"></div>';
-  it('browser.waitForElement', skip('ios', 'android'), function() {
+  it('browser.waitForElement', skip('ios', 'android')(function() {
     var startMs = Date.now();
     return browser
       .executeAsync( prepareJs(
@@ -74,11 +74,11 @@ describe('api-el ' + env.ENV_DESC, function() {
           .waitForElement("css selector", "#wrongsel .child", 0.1 * env.BASE_TIME_UNIT)
           .should.be.rejectedWith('Element condition wasn\'t satisfied!');
       });
-  });
+  }));
 
   partials['browser.waitForVisible'] =
     '<div id="theDiv"></div>';
-  it('browser.waitForVisible', skip('ios', 'android'), function() {
+  it('browser.waitForVisible', skip('ios', 'android')(function() {
     return browser
       .executeAsync( prepareJs(
         'var args = Array.prototype.slice.call( arguments, 0 );\n' +
@@ -100,7 +100,7 @@ describe('api-el ' + env.ENV_DESC, function() {
           .should.be.rejectedWith(/Element didn\'t become visible/);
 
       });
-  });
+  }));
 
   partials['browser.elements'] =
     '<div>\n' +

--- a/test/midway/api-exec-specs.js
+++ b/test/midway/api-exec-specs.js
@@ -69,7 +69,7 @@ describe('api-exec ' + env.ENV_DESC, function() {
     '  <div class="line">line 2</div>\n' +
     '  <div class="line">line 3</div>\n' +
     '</div>\n';
-  it('browser.execute - els arg', skip('ios'), function() {
+  it('browser.execute - els arg', skip('ios')(function() {
     var jsScript = prepareJs(
       'var els = arguments[0];\n' +
       'return $(els[1]).text();\n'
@@ -81,7 +81,7 @@ describe('api-exec ' + env.ENV_DESC, function() {
           .execute(jsScript, [els])
           .should.become('line 2');
       });
-  });
+  }));
 
   partials['browser.execute - el return'] =
     '<div id="theDiv"></div>';
@@ -126,7 +126,7 @@ describe('api-exec ' + env.ENV_DESC, function() {
       });
   });
 
-  it('browser.safeExecute - args', skip('android'), function() {
+  it('browser.safeExecute - args', skip('android')(function() {
     /* jshint evil: true */
     var jsScript = prepareJs(
       'var a = arguments[0], b = arguments[1];\n' +
@@ -139,9 +139,9 @@ describe('api-exec ' + env.ENV_DESC, function() {
         return browser
           .safeExecute('invalid-code> here', [6, 4]).should.be.rejectedWith(/status: 13/);
       });
-  });
+  }));
 
-  it('browser.executeAsync', skip('ios', 'android'), function() {
+  it('browser.executeAsync', skip('ios', 'android')(function() {
     var jsScript = prepareJs(
       'var args = Array.prototype.slice.call( arguments, 0 );\n' +
       'var done = args[args.length -1];\n' +
@@ -155,9 +155,9 @@ describe('api-exec ' + env.ENV_DESC, function() {
     return browser
       .executeAsync(jsScript).should.become('OK')
       .executeAsync(jsScriptWithArgs, [10, 5]).should.become('OK 15');
-  });
+  }));
 
-  it('browser.safeExecuteAsync', skip('ios', 'android'), function() {
+  it('browser.safeExecuteAsync', skip('ios', 'android')(function() {
     var jsScript = prepareJs(
       'var args = Array.prototype.slice.call( arguments, 0 );\n' +
       'var done = args[args.length -1];\n' +
@@ -179,9 +179,9 @@ describe('api-exec ' + env.ENV_DESC, function() {
           return browser.safeExecuteAsync('123 invalid<script', [10, 5])
             .should.be.rejectedWith(/status: (13|17)/);
       });
-  });
+  }));
 
-  it('browser.setAsyncScriptTimeout', skip('ios', 'android'), function() {
+  it('browser.setAsyncScriptTimeout', skip('ios', 'android')(function() {
     var jsScript = prepareJs(
       'var args = Array.prototype.slice.call( arguments, 0 );\n' +
       'var done = args[args.length -1];\n' +
@@ -195,12 +195,12 @@ describe('api-exec ' + env.ENV_DESC, function() {
       .setAsyncScriptTimeout( 2* env.BASE_TIME_UNIT )
       .executeAsync( jsScript, [env.BASE_TIME_UNIT])
       .setAsyncScriptTimeout(0);
-  });
+  }));
 
 
   partials['browser.waitForCondition'] =
     '<div id="theDiv"></div>\n';
-  it('browser.waitForCondition', skip('ios', 'android'), function() {
+  it('browser.waitForCondition', skip('ios', 'android')(function() {
     var exprCond = "$('#theDiv .child').length > 0";
     return browser
       .executeAsync( prepareJs(
@@ -219,11 +219,11 @@ describe('api-exec ' + env.ENV_DESC, function() {
       .then(function() {
         return browser.waitForCondition('$wrong expr!!!').should.be.rejectedWith(/status: 13/);
       });
-  });
+  }));
 
   partials['browser.waitForConditionInBrowser'] =
     '<div id="theDiv"></div>\n';
-  it('browser.waitForConditionInBrowser', skip('ios', 'android'), function() {
+  it('browser.waitForConditionInBrowser', skip('ios', 'android')(function() {
     var exprCond = "$('#theDiv .child').length > 0";
     return browser
       .executeAsync( prepareJs(
@@ -247,6 +247,6 @@ describe('api-exec ' + env.ENV_DESC, function() {
           .should.be.rejectedWith(/status: (13|17)/);
       })
       .setAsyncScriptTimeout(0);
-  });
+  }));
 
 });

--- a/test/midway/api-nav-specs.js
+++ b/test/midway/api-nav-specs.js
@@ -96,7 +96,7 @@ describe('api-nav ' + env.ENV_DESC, function() {
     '  <div class="div2" href="#">div 1</div>\n' +
     '  <div class="current"></div>\n' +
     '</div>\n';
-  it('browser.moveTo', skip('ios', 'android'), function() {
+  it('browser.moveTo', skip('ios', 'android')(function() {
     if(true || env.BROWSER === 'explorer') {
       // cannot get hover to work in explorer
       return browser
@@ -138,11 +138,11 @@ describe('api-nav ' + env.ENV_DESC, function() {
             .elementByCss('#theDiv .current').text().should.become('div 1');
         });
     }
-  });
+  }));
 
   partials['browser.buttonDown/browser.buttonUp'] =
     '<div id="theDiv"><a>hold me</a><div class="res"></div></div>\n';
-  it('browser.buttonDown/browser.buttonUp', skip('ios', 'android'), function() {
+  it('browser.buttonDown/browser.buttonUp', skip('ios', 'android')(function() {
     return browser
       .execute( prepareJs(
         'jQuery( function() {\n' +
@@ -171,14 +171,14 @@ describe('api-nav ' + env.ENV_DESC, function() {
           .buttonUp(0)
           .elementByCss('#theDiv .res').text().should.become('button up');
       });
-  });
+  }));
 
   partials['browser.click'] =
     '<div id="theDiv">\n' +
     '  <div class="numOfClicks">not clicked</div>\n' +
     '  <div class="buttonNumber">not clicked</div>\n' +
     '</div>\n';
-  it('browser.click', skip('ios', 'android'), function() {
+  it('browser.click', skip('ios', 'android')(function() {
     return browser
       .execute( prepareJs(
         'jQuery( function() {\n' +
@@ -217,13 +217,13 @@ describe('api-nav ' + env.ENV_DESC, function() {
             }
           });
       });
-  });
+  }));
 
   partials['browser.doubleclick'] =
     '<div id="theDiv">\n' +
     '  <div>not clicked</div>\n' +
     '</div>\n';
-  it('browser.doubleclick', skip('ios', 'android'), function() {
+  it('browser.doubleclick', skip('ios', 'android')(function() {
     return browser
       .execute( prepareJs(
         'jQuery( function() {\n' +
@@ -240,7 +240,7 @@ describe('api-nav ' + env.ENV_DESC, function() {
           .doubleclick()
           .elementByCss('#theDiv div').text().should.become('doubleclicked');
       });
-  });
+  }));
 
   if(!env.SAUCE) {
     // weird stuff with keying spaces on Sauce at the moment, commenting
@@ -260,7 +260,7 @@ describe('api-nav ' + env.ENV_DESC, function() {
         .elementByCss("#theDiv input").type("not cleared")
         .getValue().should.become('not cleared')
         .elementByCss("#theDiv input").clear().getValue().should.become('');
-    });    
+    });
   }
 
   it('browser.title', function() {
@@ -269,7 +269,7 @@ describe('api-nav ' + env.ENV_DESC, function() {
 
   partials['browser.acceptAlert'] =
     '<div id="theDiv"><a>click me</a></div>\n';
-  it('browser.acceptAlert', skip('ios', 'android'), function() {
+  it('browser.acceptAlert', skip('ios', 'android')(function() {
     return browser
       .execute( prepareJs(
         'jQuery( function() {\n' +
@@ -282,11 +282,11 @@ describe('api-nav ' + env.ENV_DESC, function() {
       )
       .elementByCss("#theDiv a").click()
       .acceptAlert();
-  });
+  }));
 
   partials['browser.dismissAlert'] =
     '<div id="theDiv"><a>click me</a></div>\n';
-  it('browser.dismissAlert', skip('chrome', 'ios', 'android'), function() {
+  it('browser.dismissAlert', skip('chrome', 'ios', 'android')(function() {
     return browser
       .execute( prepareJs(
         'jQuery( function() {\n' +
@@ -299,6 +299,6 @@ describe('api-nav ' + env.ENV_DESC, function() {
       )
       .elementByCss("#theDiv a").click()
       .dismissAlert();
-  });
+  }));
 
 });

--- a/test/midway/api-various-specs.js
+++ b/test/midway/api-various-specs.js
@@ -81,7 +81,7 @@ describe('api-various ' + env.ENV_DESC, function() {
 
   partials['browser.dismissAlert'] =
     '<div id="theDiv"><a>click me</a></div>\n';
-  it('browser.dismissAlert', skip('chrome'), function() {
+  it('browser.dismissAlert', skip('chrome')(function() {
     return browser
       .execute(
         'jQuery( function() {\n' +
@@ -94,7 +94,7 @@ describe('api-various ' + env.ENV_DESC, function() {
       )
       .elementByCss("#theDiv a").click()
       .dismissAlert();
-  });
+  }));
 
   it('browser.takeScreenshot', function() {
     return browser
@@ -139,7 +139,7 @@ describe('api-various ' + env.ENV_DESC, function() {
   });
 
   // cookie don't seem to work in explorer
-  it('browser.<cookie methods>', skip('explorer'), function() {
+  it('browser.<cookie methods>', skip('explorer')(function() {
     return browser
       .deleteAllCookies()
       .allCookies().should.eventually.deep.equal([])
@@ -184,7 +184,7 @@ describe('api-various ' + env.ENV_DESC, function() {
         secure: true
       })
       .deleteAllCookies();
-  });
+  }));
 
   it('browser.<localStorage methods>', function() {
     return browser

--- a/test/midway/mobile-specs.js
+++ b/test/midway/mobile-specs.js
@@ -1,17 +1,17 @@
 require('../helpers/setup');
 
-describe('mobile ' + env.ENV_DESC, skip('chrome', 'firefox', 'explorer'), function() {
+describe('mobile ' + env.ENV_DESC, skip('chrome', 'firefox', 'explorer')(function() {
   var partials = {};
 
   var browser;
   require('./midway-base')(this, partials).then(function(_browser) { browser = _browser; });
 
-  it('browser.setOrientation', skip('ios'), function() {
+  it('browser.setOrientation', skip('ios')(function() {
     return browser
       .setOrientation('LANDSCAPE');
-  });
+  }));
 
-  if (!env.SAUCE) {    
+  if (!env.SAUCE) {
     it('browser.settings', function() {
       return browser
         .settings();
@@ -21,7 +21,7 @@ describe('mobile ' + env.ENV_DESC, skip('chrome', 'firefox', 'explorer'), functi
       return browser
         .updateSettings({'cyberdelia': 'open'})
         .settings().should.eventually.have.property('cyberdelia');
-    });    
+    });
   }
 
-});
+}));

--- a/test/midway/window-specs.js
+++ b/test/midway/window-specs.js
@@ -1,7 +1,7 @@
 require('../helpers/setup');
 
 // disabling because of random errors on sauce
-describe('window ' + env.ENV_DESC, skip('explorer'), function() {
+describe('window ' + env.ENV_DESC, skip('explorer')(function() {
 
   beforeEach(function() {
     return browser.windowHandles().should.eventually.have.length.below(2);
@@ -97,7 +97,7 @@ describe('window ' + env.ENV_DESC, skip('explorer'), function() {
   });
 
   partials['browser.setWindowSize'] = "";
-  it('browser.setWindowSize', skip('chrome'), function() {
+  it('browser.setWindowSize', skip('chrome')(function() {
     // bug with chrome
     return browser
       .getWindowSize().then(function(size) {
@@ -116,7 +116,7 @@ describe('window ' + env.ENV_DESC, skip('explorer'), function() {
               });
           });
       });
-  });
+  }));
 
   partials['browser.getWindowPosition'] = "";
   it('browser.getWindowPosition', function() {
@@ -153,4 +153,4 @@ describe('window ' + env.ENV_DESC, skip('explorer'), function() {
       });
   });
 
-});
+}));

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
 --require ./test/helpers/quit-gracefully
---ui bdd-with-opts
+--ui bdd
 --reporter spec
 --timeout 60000

--- a/test/specs/mjson-specs.js
+++ b/test/specs/mjson-specs.js
@@ -985,6 +985,19 @@ describe("mjson tests", function() {
           .activeIMEEngine()
           .nodeify(done);
       });
+
+      it("getDeviceTime", function (done) {
+        nock.cleanAll();
+        server
+          .get('/session/1234/appium/device/system_time')
+          .reply(200, {
+            status: 0,
+            sessionId: '1234'
+          });
+        browser
+          .getDeviceTime()
+          .nodeify(done);
+      });
     });
   });
 


### PR DESCRIPTION
[bdd_with_opts](https://github.com/sebv/mocha-bdd-with-opts) overwrites mocha's `it.only`, and hasn't been updated since 2014. Its implementation doesn't work with mocha 2.2.5, which is the version that "npm install" selects, based on the `package.json` dependencies.