### PR TITLE
waitFor considers errors whose message includes "timeout" retriable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 - [Site](http://admc.io/wd/)
 - [Mailing List](https://groups.google.com/forum/#!forum/wdjs)
 
+This library is designed to be a maleable implementation of the webdriver protocol in Node, exposing functionality via a number of programming paradigms. If you are looking for a more polished, opinionated and active library - I would suggest [webdriver.io](http://webdriver.io/).
+
 ## Release Notes
 [here](https://github.com/admc/wd/blob/master/doc/release-notes.md)
 

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -882,12 +882,12 @@ commands.waitFor = function(){
 
   function poll(isFinalCheck){
     unpromisedAsserter.assert(_this, function(err, satisfied, value) {
-      if(err) { return cb(err); }
+      if(err && err.message.indexOf("timeout") === -1) { return cb(err); }
       if(satisfied) {
         cb(null, value);
       } else {
         if(isFinalCheck) {
-          cb(new Error("Condition wasn't satisfied!"));
+          cb(err || new Error("Condition wasn't satisfied!"));
         } else if(Date.now() > endTime){
           // trying one more time for safety
           setTimeout(poll.bind(null, true) , opts.pollFreq);

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "webdriverjs",
     "selenium"
   ],
-  "version": "0.3.12",
+  "version": "0.4.0",
   "author": "Adam Christian <adam.christian@gmail.com>",
   "contributors": [
     "Ruben Daniels (https://github.com/javruben)",

--- a/test/midway/wait-for-timeout-specs.js
+++ b/test/midway/wait-for-timeout-specs.js
@@ -1,0 +1,83 @@
+require('../helpers/setup');
+
+describe('wait-for-timeout ' + env.ENV_DESC, function() {
+  var Asserter = wd.Asserter;
+  var page = '<div id="theDiv"></div>';
+
+  var appendChild =
+    'setTimeout(function() {\n' +
+    ' $("#theDiv").append("<div class=\\"child\\">a waitFor child</div>");\n' +
+    '}, arguments[0]);\n';
+
+  var removeChildren =
+    '$("#theDiv").empty();\n';
+
+  var flakyTimeoutAsserter = new Asserter(
+    function(browser, cb) {
+      browser.text(function(err, text) {
+        if(err) { return cb(err); }
+        if(text.match(/a waitFor child/)) {
+          cb( null, true, "It worked!" );
+        } else {
+          cb( new Error("Pretending to be a timeout error"), false, "Error branch" );
+        }
+      });
+    }
+  );
+
+  var errorAsserter = new Asserter(
+    function(browser, cb) {
+      browser.text(function(err, text) {
+        if(err) { return cb(err); }
+        if(text.match(/a waitFor child/)) {
+          cb( null, true, "Error ignored!" );
+        } else {
+          cb( new Error("Pretending to be a real error"), false, "Error branch" );
+        }
+      });
+    }
+  );
+
+  var timeoutErrorAsserter = new Asserter(
+    function(browser, cb) {
+      browser.text(function(err, text) {
+        if(err) { return cb(err); }
+        cb( new Error("Pretending to be a timeout error"), false, "Error branch" );
+      });
+    }
+  );
+
+  var partials = {};
+
+  var browser;
+  require('./midway-base')(this, partials).then(function(_browser) { browser = _browser; });
+
+  partials['browser.waitFor'] = page;
+  it('browser.waitFor', function() {
+    return browser
+
+      .execute( appendChild, [env.BASE_TIME_UNIT] )
+      .text().should.eventually.not.include('a waitFor child')
+      .waitFor(flakyTimeoutAsserter , 2 * env.BASE_TIME_UNIT, 100)
+        .should.become("It worked!")
+      .waitFor( { asserter: flakyTimeoutAsserter, timeout: 2 * env.BASE_TIME_UNIT,
+        pollFreq: 100 } )
+      .waitFor( flakyTimeoutAsserter , 2 * env.BASE_TIME_UNIT).should.become("It worked!")
+      .waitFor( flakyTimeoutAsserter ).should.become("It worked!")
+
+      .execute( removeChildren )
+      .execute( appendChild, [env.BASE_TIME_UNIT] )
+      .waitFor( errorAsserter , 2 * env.BASE_TIME_UNIT)
+        .should.be.rejectedWith(/Pretending to be a real error/)
+
+      .then(function() {
+        return browser
+
+          .execute( removeChildren )
+          .execute( appendChild, [env.BASE_TIME_UNIT] )
+          .waitFor( timeoutErrorAsserter, 0.1 * env.BASE_TIME_UNIT, 100 )
+          .should.be.rejectedWith(/Pretending to be a timeout error/);
+
+      });
+  });
+});


### PR DESCRIPTION
All tests (`gulp test`) pass for me locally.

At a high level, this seems reasonable, assuming that a timeout error might be caused by the fact that the condition we're checking for has not been met yet. Since we're willing to wait for the condition to become true, we should be willing to retry when a timeout happens.

Concretely, this patch is motivated by the need to stabilize a flaky test in our suite that fails due to a tough bug in ChromeDriver [1, 2, 3]. The failure mode is transient, so retrying fixes the flakiness.

[1] https://bugs.chromium.org/p/chromedriver/issues/detail?id=402
[2] https://bugs.chromium.org/p/chromedriver/issues/detail?id=817
[3]
http://stackoverflow.com/questions/34926866/selenium-chromedriver-timed-out-receiving-message-from-renderer-exception
