### PR TITLE
Fixed issue [setOrientation("landscape")]/ [setOrientation("portrait")] Error response status: 777

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -2043,6 +2043,7 @@ commands.getOrientation = function() {
  * @jsonWire POST /session/:sessionId/orientation
  */
 commands.setOrientation = function(orientation) {
+  orientation = orientation.toUpperCase();
   var cb = findCallback(arguments);
   this._jsonWireCall({
     method: 'POST'


### PR DESCRIPTION
As [documentation](https://github.com/admc/wd/blob/master/doc/api.md), we can use setOrientation with two values `landscape` and `portrait` to rotate on devices.

1. I use two commands below and run pass with Xcode 7 & Appium 1.5.3.
```
.setOrientation('landscape')
.setOrientation('portrait')
```

2. It doesn't work with the Xcode version 8.1 & Appium 1.6.0. It throws errors:
```
     Uncaught Error: [setOrientation("landscape")] Error response status: 777
      at exports.newError (node_modules/wd/lib/utils.js:139:13)
      at node_modules/wd/lib/callbacks.js:33:23
      at node_modules/wd/lib/webdriver.js:174:5
      at Request._callback (node_modules/wd/lib/http-utils.js:87:7)
      at Request.self.callback (node_modules/wd/node_modules/request/request.js:368:22)
      at Request.<anonymous> (node_modules/wd/node_modules/request/request.js:1219:14)
      at IncomingMessage.<anonymous> (node_modules/wd/node_modules/request/request.js:1167:12)
      at endReadableNT (_stream_readable.js:974:12)
      at _combinedTickCallback (internal/process/next_tick.js:74:11)
      at process._tickCallback (internal/process/next_tick.js:98:9)
```