### PR TITLE
Support streaming of jsonWire call responses

### DIFF
--- a/lib/http-utils.js
+++ b/lib/http-utils.js
@@ -99,3 +99,8 @@ var requestWithoutRetry = function(httpOpts, emit, cb) {
   });
 };
 exports.requestWithoutRetry = requestWithoutRetry;
+
+var requestStream = function(httpOpts) {
+  return request(httpOpts);
+};
+exports.requestStream = requestStream;

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -173,11 +173,15 @@ Webdriver.prototype._jsonWireCall = function(opts) {
   var data = opts.data || {};
   httpOpts.prepareToSend(url, data);
   // building request
-  httpUtils.requestWithRetry(httpOpts, this._httpConfig, this.emit.bind(this), function(err, res, data) {
-    if(err) { return cb(err); }
-    data = strip(data);
-    cb(null, data || "");
-  });
+  if (opts.stream) {
+    return httpUtils.requestStream(httpOpts);
+  } else {
+    httpUtils.requestWithRetry(httpOpts, this._httpConfig, this.emit.bind(this), function(err, res, data) {
+      if(err) { return cb(err); }
+      data = strip(data);
+      cb(null, data || "");
+    });
+  }
 };
 
 Webdriver.prototype._sauceJobUpdate = function(jsonData, done) {


### PR DESCRIPTION
Some calls to jsonWire endpoints - in particular `log` - can potentially return large volumes of data, which is not ideally suited to being aggregated in memory and returned in a callback, and is much better consumed by the client as a stream. So add an option to `_jsonWireCall` to support building custom methods which can consume the response as a stream.

---

The context for this is a tool I am working on (https://npmjs/timeliner) which exports the performance logs from chrome devtools when running a page in chromedriver to export various performance metrics. However the performance tracing logs can be _quite large_ and so for long running pages frequently cause the process to crash due to memory limits when consuming the logs.

By streaming the logs I can filter out non-pertinent entries without aggregating the entire log into memory and so no longer hit memory limits. See also (https://github.com/lennym/timeliner/commit/0f1f2524499d7f523246ed00003580c9ed7f62db)