### PR TITLE
Replaced `<obj> instanceof Array` with `Array.isArray()`

### DIFF
--- a/lib/callbacks.js
+++ b/lib/callbacks.js
@@ -130,7 +130,7 @@ exports.elementsCallback = function(cb, browser) {
     if(err) {return cb(err);}
     if(isWebDriverException(obj.value)) {return cb(newError(
       {message:obj.value.message,cause:obj.value}));}
-    if (!(obj.value instanceof Array)) {return cb(newError(
+    if (!Array.isArray(obj.value)) {return cb(newError(
       {message:"Response value field is not an Array.", cause:obj.value}));}
     var i, elements = [];
     for (i = 0; i < obj.value.length; i++) {
@@ -152,7 +152,7 @@ exports.elementOrElementsCallback = function(cb, browser) {
     if (obj.value.ELEMENT){
       el = browser.newElement(obj.value.ELEMENT);
       cb(null, el);
-    } else if (obj.value instanceof Array){
+    } else if (Array.isArray(obj.value)){
       var i, elements = [];
       for (i = 0; i < obj.value.length; i++) {
         el = browser.newElement(obj.value[i].ELEMENT);

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1711,7 +1711,7 @@ commands.doubleclick = function() {
  */
 commands.type = function(element, keys) {
   var cb = findCallback(arguments);
-  if (!(keys instanceof Array)) {keys = [keys];}
+  if (!Array.isArray(keys)) {keys = [keys];}
   // ensure all keystrokes are strings to conform to JSONWP
   _.each(keys, function(key, idx) {
     if (typeof key !== "string") {
@@ -1728,7 +1728,7 @@ commands.type = function(element, keys) {
 
 commands.replace = function(element, keys) {
   var cb = findCallback(arguments);
-  if (!(keys instanceof Array)) {keys = [keys];}
+  if (!Array.isArray(keys)) {keys = [keys];}
   // ensure all keystrokes are strings to conform to JSONWP
   _.each(keys, function(key, idx) {
     if (typeof key !== "string") {
@@ -1767,7 +1767,7 @@ commands.submit = function(element) {
  */
 commands.keys = function(keys) {
   var cb = findCallback(arguments);
-  if (!(keys instanceof Array)) {keys = [keys];}
+  if (!Array.isArray(keys)) {keys = [keys];}
   // ensure all keystrokes are strings to conform to JSONWP
   _.each(keys, function(key, idx) {
     if (typeof key !== "string") {

--- a/lib/element-commands.js
+++ b/lib/element-commands.js
@@ -46,7 +46,7 @@ function _isLocalFile(path, cb) {
  */
 elementCommands.sendKeys = function (keys, cb) {
   var _this = this;
-  if (!(keys instanceof Array)) {keys = [keys];}
+  if (!Array.isArray(keys)) {keys = [keys];}
 
   // ensure all keystrokes are strings to conform to JSONWP
   _.each(keys, function(key, idx) {
@@ -76,7 +76,7 @@ elementCommands.sendKeys = function (keys, cb) {
  */
 elementCommands.setText = function (keys, cb) {
   var _this = this;
-  if (!(keys instanceof Array)) {keys = [keys];}
+  if (!Array.isArray(keys)) {keys = [keys];}
 
   // ensure all keystrokes are strings to conform to JSONWP
   _.each(keys, function(key, idx) {


### PR DESCRIPTION
I've been seeing a bug where at certain points in my tests, code to
retrieve elements like this:

```
driver.elementsByAccessibilityId("foo bar")
```

would throw an error:

```
[elementsByAccessibilityId("foo bar")] Response value field is not an Array.
```

After looking into the for wd code, I could see this was happening in
`callbacks.js:133`, in code that checked whether the return value was an
array, using `instanceof Array`. When I inspected what this code was
doing at runtime the value really was an array, but `instanceof Array`
was still returning false. Strangely I could reproduce the original
error when I ran my tests via Jest but not when I ran the same code in
the wd repl (where `instanceof Array` would return true at the same place).

It turns out that `instanceof Array` can return false for an array
created in another window or frame (or process?). See
http://web.mit.edu/jwalden/www/isArray.html for a full
explanation of this. `Array.isArray()` was added to ES5 for exactly this
reason, so I have replaced `instanceof  Array` with `Array.isArray()`
throughout the codebase.

With this change I wd behaves as I would expect both in the repl and in
Jest.