### PR TITLE
Use `tmpdir` to solve Node 7 deprecation

### DIFF
--- a/lib/tmp.js
+++ b/lib/tmp.js
@@ -39,7 +39,7 @@ function _getTMPDir() {
 
 var
   exists = fs.exists || path.exists,
-  tmpDir = os.tmpDir || _getTMPDir,
+  tmpDir = os.tmpdir || os.tmpDir || _getTMPDir,
   _TMP = tmpDir(),
   randomChars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz",
   randomCharsLength = randomChars.length;


### PR DESCRIPTION
```
(node:49216) DeprecationWarning: os.tmpDir() is deprecated. Use os.tmpdir() instead.
    at Object.<anonymous> (/Users/federicozivolo/Progetti/popper-js/node_modules/wd/lib/tmp.js:43:10)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/federicozivolo/Progetti/popper-js/node_modules/wd/lib/commands.js:4:11)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
```

This patch aims to get rid of this deprecation warning on Node 7