### PR TITLE
updated archiver

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lib": "./lib"
   },
   "dependencies": {
-    "archiver": "1.1.0",
+    "archiver": "1.3.0",
     "async": "2.0.1",
     "lodash": "4.16.2",
     "q": "1.4.1",


### PR DESCRIPTION
Tests seem to run fine.

Motivation: Get rid of _"wd > archiver > glob > minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue"_ warnings.