### PR TITLE
Build browser scripts after install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp
 temp
 .npmignore
 *.log
+build/

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -17,7 +17,10 @@ var fs = require("fs"),
     codeToString = utils.codeToString,
     deprecator = utils.deprecator,
     asserters = require("./asserters"),
-    Asserter = asserters.Asserter;
+    Asserter = asserters.Asserter,
+    safeExecuteJsScript = require('../build/safe-execute');;
+    safeExecuteAsyncJsScript = require('../build/safe-execute-async');;
+    _waitForConditionInBrowserJsScript = require('../build/wait-for-cond-in-browser');;
 
 var commands = {};
 
@@ -95,10 +98,6 @@ commands.execute = function() {
     , data: {script: code, args: args}
   });
 };
-
-// script to be executed in browser
-var safeExecuteJsScript =
-  utils.inlineJs(fs.readFileSync( __dirname + "/../browser-scripts/safe-execute.js", 'utf8'));
 
 /**
  * Safely execute script within an eval block, always returning:
@@ -179,10 +178,6 @@ commands.safeEval = function(code) {
     , data: {script: code, args: args}
   });
 };
-
-// script to be executed in browser
-var safeExecuteAsyncJsScript =
-  utils.inlineJs(fs.readFileSync( __dirname + "/../browser-scripts/safe-execute-async.js", 'utf8'));
 
 /**
  * Safely execute async script within an eval block, always returning:
@@ -2285,10 +2280,6 @@ commands.waitForJsCondition = function(){
 };
 commands.waitForCondition = commands.waitForJsCondition;
 
-// script to be executed in browser
-var _waitForConditionInBrowserJsScript =
-  utils.inlineJs(fs.readFileSync( __dirname + "/../browser-scripts/wait-for-cond-in-browser.js", 'utf8'));
-
 /**
  * Waits for JavaScript condition to be true (async script polling within browser):
  * waitForConditionInBrowser(conditionExpr, timeout, pollFreq, cb) -> cb(err, boolean)
@@ -3111,7 +3102,6 @@ commands.getDeviceTime = function () {
  * @jsonWire GET /session/:sessionId/appium/simulator/touch_id
  */
 commands.touchId = function(){
-  var cb = findCallback(arguments);
   var fargs = utils.varargs(arguments);
   var cb = fargs.callback,
       match = fargs.all[0];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -88,11 +88,6 @@ exports.deprecator = {
   }
 };
 
-// Android doesn't like cariage return
-exports.inlineJs = function(script) {
-  return script.replace(/[\r\n]/g,'').trim();
-};
-
 exports.resolveUrl = function(from, to) {
   if(typeof from === 'object') { from = url.format(from); }
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "istanbul": "0.4.5",
     "jshint": "2.9.3",
     "jshint-stylish": "2.2.1",
+    "mkdirp": "^0.5.1",
     "mocha": "3.1.0",
     "mu2": "0.5.21",
     "nock": "8.0.0",
@@ -79,6 +80,7 @@
   },
   "scripts": {
     "test": "gulp test-unit",
-    "all_tests": "gulp test"
+    "all_tests": "gulp test",
+    "install": "node scripts/build-browser-scripts"
   }
 }

--- a/scripts/build-browser-scripts.js
+++ b/scripts/build-browser-scripts.js
@@ -1,0 +1,9 @@
+var fs = require('fs');
+var mkdirp = require('mkdirp').sync;
+var safeExecute = fs.readFileSync(__dirname + '/../browser-scripts/safe-execute.js', 'utf8').replace(/[\r\n]/g, '').trim();
+var safeExecuteAsync = fs.readFileSync(__dirname + '/../browser-scripts/safe-execute-async.js', 'utf8').replace(/[\r\n]/g, '').trim();
+var waitForCondInBrowser = fs.readFileSync(__dirname + '/../browser-scripts/wait-for-cond-in-browser.js', 'utf8').replace(/[\r\n]/g, '').trim();
+mkdirp(__dirname + '/../build');
+fs.writeFileSync(__dirname + '/../build/safe-execute.js', 'module.exports = "' + safeExecute + '"');
+fs.writeFileSync(__dirname + '/../build/safe-execute-async.js', 'module.exports = "' + safeExecuteAsync + '"');
+fs.writeFileSync(__dirname + '/../build/wait-for-cond-in-browser.js', 'module.exports = "' + waitForCondInBrowser + '"');


### PR DESCRIPTION
Because commands.js was importing scripts using __dirname, this causes problems when you bundle 'wd' into an electron app because the __dirname won't point to the correct directory. Solution is to write an npm script that's fired after install that takes the contents of the browser scripts and then builds them as files that export the Javascript as a string.

(@jlipps Can you have a look at this too)