### PR TITLE
Add inlineJS back to utils.js

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -18,9 +18,9 @@ var fs = require("fs"),
     deprecator = utils.deprecator,
     asserters = require("./asserters"),
     Asserter = asserters.Asserter,
-    safeExecuteJsScript = require('../build/safe-execute');;
-    safeExecuteAsyncJsScript = require('../build/safe-execute-async');;
-    _waitForConditionInBrowserJsScript = require('../build/wait-for-cond-in-browser');;
+    safeExecuteJsScript = require('../build/safe-execute'),
+    safeExecuteAsyncJsScript = require('../build/safe-execute-async'),
+    _waitForConditionInBrowserJsScript = require('../build/wait-for-cond-in-browser');
 
 var commands = {};
 

--- a/lib/promise-webdriver.js
+++ b/lib/promise-webdriver.js
@@ -124,7 +124,7 @@ module.exports = function(WebDriver, Element, chainable) {
         .each(function(fname) {
           var _orig = promise[fname];
           promise[fname] = function() {
-            var subobj = _orig.apply(this, __slice.call(arguments, 0))
+            var subobj = _orig.apply(this, __slice.call(arguments, 0));
 
             return this._enrich(
               subobj, currentEl);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -88,6 +88,11 @@ exports.deprecator = {
   }
 };
 
+// Android doesn't like cariage return		
+exports.inlineJs = function(script) {		
+  return script.replace(/[\r\n]/g,'').trim();		
+};
+
 exports.resolveUrl = function(from, to) {
   if(typeof from === 'object') { from = url.format(from); }
 


### PR DESCRIPTION
Shouldn't have been removed. It's still being used by setup.js