### PR TITLE
Report error if method not available in requested scope

### DIFF
--- a/lib/promise-webdriver.js
+++ b/lib/promise-webdriver.js
@@ -169,6 +169,14 @@ module.exports = function(WebDriver, Element, chainable) {
               throw new Error("Invalid method " + fname);
             }
 
+            // Report error if method in requested scope is not available.
+            if (!isBrowserMethod && (scopeHint === '<')) {
+              throw new Error("No method in browser scope " + fname);
+            }
+            if (!isElementMethod && (scopeHint === '>')) {
+              throw new Error("No method in element scope " + fname);
+            }
+
             if(isBrowserMethod && isElementMethod) {
               // we need to resolve the conflict.
               if(scopeHint === '<') {


### PR DESCRIPTION
### The problem

When I write code like 
```
element.waitForElementByCss('>', '.big-red-thing');
```
Then I expect it to search for in element's scope. But it silently searches in document's scope.

Can we make this an explicit error like proposed?