### PR TITLE
waitFor Timeout Fix

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -839,6 +839,8 @@ commands.waitFor = function(){
   var cb = findCallback(arguments);
   var fargs = utils.varargs(arguments);
   var opts;
+  var toId = null;
+
   // retrieving options
   if(typeof fargs.all[0] === 'object' && !(fargs.all[0] instanceof Asserter)){
     opts = fargs.all[0];
@@ -875,22 +877,24 @@ commands.waitFor = function(){
     }
   );
 
+  unpromisedAsserter.assert(_this, function(err, satisfied, value) {
+    if(err) { return cb(err); }
+    if(satisfied) {
+      cb(null, value);
+      clearTimeout(toId);
+    } 
+  });
+
   function poll(isFinalCheck){
-    unpromisedAsserter.assert(_this, function(err, satisfied, value) {
-      if(err) { return cb(err); }
-      if(satisfied) {
-        cb(null, value);
-      } else {
-        if(isFinalCheck) {
-          cb(new Error("Condition wasn't satisfied!"));
-        } else if(Date.now() > endTime){
-          // trying one more time for safety
-          setTimeout(poll.bind(null, true) , opts.pollFreq);
-        } else {
-          setTimeout(poll, opts.pollFreq);
-        }
-      }
-    });
+    if(isFinalCheck) {
+      cb(new Error("Condition wasn't satisfied!"));
+    } else if(Date.now() > endTime){
+      // trying one more time for safety
+      toId = setTimeout(poll.bind(null, true) , opts.pollFreq);
+    } else {
+      toId = setTimeout(poll, opts.pollFreq);
+    }
+
   }
 
   poll();


### PR DESCRIPTION
Referenced from issue #442. 

> The problem is that wait for only polls every time the asserter promise is either resolved or rejected. Imagine your promise is only resolved on fetching a value over http that takes 5 seconds but your timeout is 2 seconds - the timeout will fail to execute because it only ticks on promise resolution or rejection not time intervals (as it should be).

This revision has been used in a production-grade system since I forked the project in February.  Since there have been quite a few contributions since then, I thought I would contribute back to mainline.
