### PR TITLE
Add rejectUnauthorized to http config opts

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -5,7 +5,8 @@ var httpConfig = {
   retries: 3,
   retryDelay: 15,
   baseUrl: undefined,
-  proxy: undefined
+  proxy: undefined,
+  rejectUnauthorized: true,
 };
 
 function _configureHttp(httpConfig, opts) {

--- a/lib/http-utils.js
+++ b/lib/http-utils.js
@@ -43,6 +43,7 @@ exports.newHttpOpts = function(method, httpConfig) {
   opts.headers.Connection = 'keep-alive';
   opts.headers['User-Agent'] = 'admc/wd/' + packageDotJson.version;
   opts.timeout = httpConfig.timeout;
+  opts.rejectUnauthorized = httpConfig.rejectUnauthorized;
   if(httpConfig.proxy) { opts.proxy = httpConfig.proxy; }
   // we need to check method here to cater for PUT and DELETE case
   if(opts.method === 'GET' || opts.method === 'POST'){


### PR DESCRIPTION
This is so that in Appium Desktop when a user creates, we can give them the option to ignore unrecognized certificates.