### PR TITLE
Add basic support for new W3C wire protocol

### DIFF
--- a/lib/callbacks.js
+++ b/lib/callbacks.js
@@ -16,25 +16,44 @@ exports.simpleCallback = function(cb) {
     } else {
       // looking for JsonWire response
       var jsonWireRes;
+      var jsonwireError;
+      var errorMessage;
+      var error;
       try{jsonWireRes = JSON.parse(data);}catch(ign){}
       if (jsonWireRes && (jsonWireRes.status !== undefined)) {
         // valid JsonWire response
         if(jsonWireRes.status === 0) {
           cb(null);
         } else {
-          var jsonwireError  = getJsonwireError(jsonWireRes.status);
-          var errorMessage = 'Error response status: ' + jsonWireRes.status;
+          jsonwireError  = getJsonwireError(jsonWireRes.status);
+          errorMessage = 'Error response status: ' + jsonWireRes.status;
           if(jsonwireError) {
             errorMessage += ", " + jsonwireError.summary + " - " + jsonwireError.detail;
           }
           if(jsonWireRes.value && jsonWireRes.value.message) {
             errorMessage += " Selenium error: " + jsonWireRes.value.message;
           }
-          var error = newError(
+          error = newError(
             { message: errorMessage
               , status:jsonWireRes.status
               , cause:jsonWireRes });
           if(jsonwireError){ error['jsonwire-error'] = jsonwireError; }
+          cb(error);
+        }
+      } else if (jsonWireRes.value !== undefined) {
+        // valid W3C draft spec response
+        if (jsonWireRes.value === null || Object.keys(jsonWireRes.value).length === 0) {
+          cb(null);
+        } else {
+          jsonwireError = jsonWireRes.value;
+          errorMessage = 'Error response: ' + jsonwireError.error + ' - ' +
+                             jsonwireError.message;
+          if (jsonwireError.stacktrace) {
+            errorMessage += ' - Stack trace:\n' + jsonwireError.stacktrace;
+          }
+          error = newError(
+            { message: errorMessage
+              , cause: jsonwireError });
           cb(error);
         }
       } else {

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -111,12 +111,16 @@ Webdriver.prototype._init = function() {
     try{
       jsonData = JSON.parse(data);
       if( jsonData.status === 0 ){
+        // retrieving session via old JSON wire protocol
         _this.sessionID = jsonData.sessionId;
         resData = jsonData.value;
+      } else if (jsonData.value && jsonData.value.sessionId) {
+        // retrieving session via the new W3C protocol
+        _this.sessionID = jsonData.value.sessionId;
       }
     } catch(ignore){}
     if(!_this.sessionID){
-      // attempting to retrieve the session the old way
+      // attempting to retrieve the session the OLD old way
       try{
         var locationArr = res.headers.location.replace(/\/$/, '').split('/');
         _this.sessionID = locationArr[locationArr.length - 1];


### PR DESCRIPTION
This adds basic support for the new W3C wire protocol, which fixes Firefox and IE support.

For more details, see https://github.com/SeleniumHQ/selenium/issues/5952#issuecomment-392866840

This PR also includes unrelated test fixes from PR #532

Closes #495