### PR TITLE
Add getter for TouchAction on ImageElement object

### DIFF
--- a/lib/image-element.js
+++ b/lib/image-element.js
@@ -1,7 +1,6 @@
 //ImageElement object
 //Wrapper around tap methods
 var __slice = Array.prototype.slice;
-var TouchAction = require('./actions').TouchAction;
 
 var ImageElement = function(rect, browser) {
   this.rect = rect;
@@ -30,10 +29,21 @@ ImageElement.prototype.toJSON = function () {
   return this.rect;
 };
 
+Object.defineProperty(ImageElement, 'TouchAction', {
+  // only want to load the TouchAction class once, and only after all files
+  // are loaded, so as to avoid circularity in the module loading
+  get: function () {
+    if (!this._touchAction) {
+      this._touchAction = require('./actions').TouchAction;
+    }
+    return this._touchAction;
+  }
+});
+
 ImageElement.prototype.click = function (cb) {
   var _this = this;
   this.emit('command', "CALL" , "imageElement.click()")
-  var action = new TouchAction(this.browser);
+  var action = new this.TouchAction(this.browser);
   action.tap(this.x, this.y);
   action.perform(function(err) {
     if(err) {


### PR DESCRIPTION
The way the modules are organized, loading `TouchAction` at startup causes it to be in memory before `Element` exists. This means that when you go to use an action you get a TypeError (`TypeError: Right-hand side of 'instanceof' is not callable`) since Element is not a constructor anymore.

See, for instance, the errors in https://api.travis-ci.org/v3/job/395898891/log.txt

Fix by lazily loading the class through a getter.

See also https://github.com/appium/appium/issues/10937