### PR TITLE
add flags for press keycodes

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -2504,6 +2504,8 @@ commands.pressDeviceKey = commands.deviceKeyEvent;
 /**
  * pressKeycode(keycode, metastate, cb) -> cb(err)
  * metastate is optional.
+ * flags is optional for native android flag. Can set multiple falsg as Array. Flags have `FLAG_` prefix in http://developer.android.com/reference/android/view/KeyEvent.html
+ * e.g.: FLAG_CANCELED is `32` or `0x00000020`
  *
  * @jsonWire POST /session/:sessionId/appium/device/press_keycode
  */
@@ -2511,9 +2513,15 @@ commands.pressKeycode = function() {
   var fargs = utils.varargs(arguments);
   var cb = fargs.callback,
       keycode = fargs.all[0],
-      metastate = fargs.all[1];
+      metastate = fargs.all[1],
+      flags = fargs.all[2];
   var data = {keycode: keycode};
   if(metastate) { data.metastate = metastate; }
+  if(flags) {
+    f = 0
+    flags.forEach( function (value) { f = f | value; } )
+    data.flags = f;
+   }
   this._jsonWireCall({
     method: 'POST'
     , relPath: '/appium/device/press_keycode'
@@ -2525,6 +2533,8 @@ commands.pressKeycode = function() {
 /**
  * longPressKeycode(keycode, metastate, cb) -> cb(err)
  * metastate is optional.
+ * flags is optional for native android flag. Can set multiple falsg as Array. Flags have `FLAG_` prefix in http://developer.android.com/reference/android/view/KeyEvent.html
+ * e.g.: FLAG_CANCELED is `32` or `0x00000020`
  *
  * @jsonWire POST /session/:sessionId/appium/device/long_press_keycode
  */
@@ -2532,9 +2542,15 @@ commands.longPressKeycode = function() {
   var fargs = utils.varargs(arguments);
   var cb = fargs.callback,
       keycode = fargs.all[0],
-      metastate = fargs.all[1];
+      metastate = fargs.all[1],
+      flags = fargs.all[2];
   var data = {keycode: keycode};
   if(metastate) { data.metastate = metastate; }
+  if(flags) {
+    f = 0
+    flags.forEach( function (value) { f = f | value; } )
+    data.flags = f;
+   }
   this._jsonWireCall({
     method: 'POST'
     , relPath: '/appium/device/long_press_keycode'

--- a/test/specs/mjson-specs.js
+++ b/test/specs/mjson-specs.js
@@ -690,7 +690,7 @@ describe("mjson tests", function() {
             sessionId: '1234',
             value: null,
           });
-        
+
         browser.releaseW3CActions()
           .then(function (value) {
             should.equal(value, null);
@@ -822,6 +822,19 @@ describe("mjson tests", function() {
             .pressKeycode(3, "abcd")
             .nodeify(done);
         });
+
+        it("keycode + metastate + flags", function(done) {
+          nock.cleanAll();
+          server
+            .post('/session/1234/appium/device/press_keycode', {keycode: 3, metastate: "abcd", flags: 8224})
+            .reply(200, {
+              status: 0,
+              sessionId: '1234',
+            });
+          browser
+            .pressKeycode(3, "abcd", [0x20, 0x2000])
+            .nodeify(done);
+        });
       });
 
       describe("longPressKeycode", function() {
@@ -848,6 +861,19 @@ describe("mjson tests", function() {
             });
           browser
             .longPressKeycode(3, "abcd")
+            .nodeify(done);
+        });
+
+        it("keycode + metastate + flags", function(done) {
+          nock.cleanAll();
+          server
+            .post('/session/1234/appium/device/long_press_keycode', {keycode: 3, metastate: "abcd", flags: 8224})
+            .reply(200, {
+              status: 0,
+              sessionId: '1234',
+            });
+          browser
+            .longPressKeycode(3, "abcd", [32, 8192])
             .nodeify(done);
         });
       });


### PR DESCRIPTION
http://appium.io/docs/en/commands/device/keys/press-keycode/
http://appium.io/docs/en/commands/device/keys/long-press-keycode/

`pressKeycode` and `longPressKeycode` should support `flags` to catch up with the latest spec.

We can pass multiple key flags as one number using bit operator, `OR`.

cc @dpgraham @jlipps 