### PR TITLE
Fix a typo on sessionID in webdriver

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -110,7 +110,7 @@ Webdriver.prototype._init = function() {
     // retrieving session
     try{
       jsonData = JSON.parse(data);
-      _this.sessionId = jsonData.value ? jsonData.value.sessionId : false;
+      _this.sessionID = jsonData.value ? jsonData.value.sessionId : false;
       resData = jsonData.value;
 
        if(!_this.sessionID && jsonData.status === 0 ){


### PR DESCRIPTION
Hello,

I just found a typo in the webdriver.js file which prevent the sessionID to be used and so the remote browser to be managed.

Hope this will help.