### PR TITLE
Upgrade lodash to pickup fix for prototype pollution vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2746,9 +2746,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash._basecopy": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "archiver": "2.1.1",
     "async": "2.0.1",
-    "lodash": "4.17.10",
+    "lodash": "4.17.11",
     "mkdirp": "^0.5.1",
     "q": "1.4.1",
     "request": "2.88.0",


### PR DESCRIPTION
Vulnerability details: https://hackerone.com/reports/380873
Lodash changelog: https://github.com/lodash/lodash/wiki/Changelog#v41711