### PR TITLE
Fixed 'npm run test' unit tests for Windows platform

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -34,7 +34,7 @@ function buildMochaOpts(opts) {
       R: 'spec',
       c: true
     },
-    bin: path.join(__dirname,  'node_modules/.bin/mocha'),
+    bin: path.join(__dirname,  'node_modules/.bin/' + ((process.platform !== "win32") ? 'mocha' : 'mocha.cmd')),
     concurrency: args.concurrency | process.env.CONCURRENCY || 3
   };
   if(args.grep) {


### PR DESCRIPTION
Fixed 'npm run test' unit tests for Windows platform by modifying gulpfile.js to call **node_modules/mocha/bin/mocha.cmd** on the windows platform.