### PR TITLE
fix: naming of tasks in gulp tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -184,7 +184,7 @@ gulp.task('test:e2e', function() {
 });
 
 gulp.task('test', function() {
-  var seq = ['lint', 'test-unit', 'test-midway-multi'];
+  var seq = ['lint', 'test:unit', 'test:midway:multi'];
   _(BROWSERS).each(function(browser) {
      seq.push(`test:midway:${browser}`, `test:e2e:${browser}`);
   });


### PR DESCRIPTION
Should resolve #584