### PR TITLE
Support W3C get active element command

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1987,8 +1987,9 @@ commands.dismissAlert = function() {
  */
 commands.active = function() {
   var cb = findCallback(arguments);
+  var method = this.w3c ? 'GET' : 'POST';
   this._jsonWireCall({
-    method: 'POST'
+    method: method
     , relPath: '/element/active'
     , cb: callbackWithData(cb, this)
   });

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -122,10 +122,12 @@ Webdriver.prototype._init = function() {
     try{
       jsonData = JSON.parse(data);
       _this.sessionID = jsonData.value ? jsonData.value.sessionId : false;
+      _this.w3c = false;
       resData = jsonData.value;
 
        if(!_this.sessionID && jsonData.status === 0 ){
         _this.sessionID = jsonData.sessionId;
+        _this.w3c = true;
       }
     } catch(ignore){}
     if(!_this.sessionID){


### PR DESCRIPTION
`/element/active` requires POST method in JsonWireProtocol but W3C WebDriver spec requires GET method.

https://www.w3.org/TR/webdriver/#get-active-element

This patch checks remote WebDriver server speaks JWP or W3C on creating a session and remembers it. Then switch method of `/element/active` looking the flag.