### PR TITLE
add httpAgent as right now the connection is not kept alive

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -2,6 +2,7 @@ var EventEmitter = require('events').EventEmitter,
     _ = require("lodash"),
     util = require( 'util' ),
     url = require('url'),
+    http = require('http'),
     __slice = Array.prototype.slice,
     utils = require("./utils"),
     findCallback = utils.findCallback,
@@ -20,6 +21,7 @@ var EventEmitter = require('events').EventEmitter,
 var Webdriver = module.exports = function(configUrl) {
   EventEmitter.call( this );
   this.sessionID = null;
+  this.httpAgent = null;
   this.configUrl = configUrl;
   this.sauceTestPageRoot = "https://" + SAUCE_API_HOST + "/jobs";
   this.sauceRestRoot = "https://" + SAUCE_API_HOST + "/rest/v1";
@@ -91,7 +93,9 @@ Webdriver.prototype._init = function() {
   }
 
   // http options
+  this.httpAgent = new http.Agent({ keepAlive: true });
   var httpOpts = httpUtils.newHttpOpts('POST', _this._httpConfig);
+      httpOpts.agent = this.httpAgent;
 
   var url = httpUtils.buildInitUrl(this.configUrl);
 
@@ -169,6 +173,7 @@ Webdriver.prototype._jsonWireCall = function(opts) {
 
   // http options init
   var httpOpts = httpUtils.newHttpOpts(opts.method, this._httpConfig);
+      httpOpts.agent = this.httpAgent;
 
   var url = httpUtils.buildJsonCallUrl(this.noAuthConfigUrl, this.sessionID, opts.relPath, opts.absPath);
 


### PR DESCRIPTION
Currently, the connection is not keep-alive over a test life, during some investigation at Sauce I notice this Appium(webdriver) client is closing TCP connections before any new command.
Here's some Wireshark TCP dump showing it:

<img width="1393" alt="before-keep-alive" src="https://user-images.githubusercontent.com/329957/71865250-09377800-30b7-11ea-9c3b-b136cd60d319.png">

👆🏻Before any new command(request) there's a [FIN, ACK]
<hr>
With these changes looking at TCP dumps we can see the socket is kept open, so there's no more resync before new requests 👇🏻

<img width="1417" alt="after-keep-alive" src="https://user-images.githubusercontent.com/329957/71865289-266c4680-30b7-11ea-83c8-c4360013cf25.png">

