### PR TITLE
fix: destroy keep-alive sockets on quit

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -474,11 +474,16 @@ commands.log = function(logType) {
  */
 commands.quit = function() {
   var cb = findCallback(arguments);
+  var _this = this;
+  var finalCb = function(...args) {
+    simpleCallback(cb)(...args);
+    if (_this.httpAgent) _this.httpAgent.destroy();
+  };
   this._jsonWireCall({
     method: 'DELETE'
     // default url
     , emit: {event: 'status', message: '\nEnding your web drivage..\n'}
-    , cb: simpleCallback(cb)
+    , cb: finalCb
   });
 };
 


### PR DESCRIPTION
Try to destroy the http agent's sockets when quit is called, to avoid hanging until they close on their own.

Cc: @vrunoa 