### PR TITLE
revert keep-alive until someone figures out how to fix it

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -93,7 +93,7 @@ Webdriver.prototype._init = function() {
   }
 
   // http options
-  this.httpAgent = new http.Agent({ keepAlive: true });
+  this.httpAgent = new http.Agent({ keepAlive: false });
   var httpOpts = httpUtils.newHttpOpts('POST', _this._httpConfig);
       httpOpts.agent = this.httpAgent;
 


### PR DESCRIPTION
Having keep-alive sockets causes session close to hang. Until someone makes a general solution to this, I don't think this should be here. Perhaps it could be configurable in `driver.init`? 