### PR TITLE
refactor: revert back to keep-alive sockets

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -93,7 +93,7 @@ Webdriver.prototype._init = function() {
   }
 
   // http options
-  this.httpAgent = new http.Agent({ keepAlive: false });
+  this.httpAgent = new http.Agent({ keepAlive: true });
   var httpOpts = httpUtils.newHttpOpts('POST', _this._httpConfig);
       httpOpts.agent = this.httpAgent;
 


### PR DESCRIPTION
The Appium server has been fixed to handle keep-alive sockets.