### PR TITLE
fix: Use https for https

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -94,7 +94,7 @@ Webdriver.prototype._init = function() {
   }
 
   // http options
-  this.httpAgent = (configUrl.protocol === 'https:')
+  this.httpAgent = (this.configUrl.protocol === 'https:')
     ? new https.Agent({ keepAlive: false })
     : new http.Agent({ keepAlive: false });
   var httpOpts = httpUtils.newHttpOpts('POST', _this._httpConfig);

--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -3,6 +3,7 @@ var EventEmitter = require('events').EventEmitter,
     util = require( 'util' ),
     url = require('url'),
     http = require('http'),
+    https = require('https'),
     __slice = Array.prototype.slice,
     utils = require("./utils"),
     findCallback = utils.findCallback,
@@ -93,7 +94,9 @@ Webdriver.prototype._init = function() {
   }
 
   // http options
-  this.httpAgent = new http.Agent({ keepAlive: false });
+  this.httpAgent = (configUrl.protocol === 'https:')
+    ? new https.Agent({ keepAlive: false })
+    : new http.Agent({ keepAlive: false });
   var httpOpts = httpUtils.newHttpOpts('POST', _this._httpConfig);
       httpOpts.agent = this.httpAgent;
 


### PR DESCRIPTION
Current implementation leads below error when wd tries to connect to https since webdriver always refers http module.

```
[0] TypeError [ERR_INVALID_PROTOCOL]: Protocol "https:" not supported. Expected "http:"
[0]     at new ClientRequest (_http_client.js:144:11)
[0]     at Object.request (https.js:309:10)
[0]     at Request.start (/Users/kazu/GitHub/appium-desktop/node_modules/request/request.js:751:32)
[0]     at Request.write (/Users/kazu/GitHub/appium-desktop/node_modules/request/request.js:1497:10)
[0]     at end (/Users/kazu/GitHub/appium-desktop/node_modules/request/request.js:549:18)
[0]     at Immediate._onImmediate (/Users/kazu/GitHub/appium-desktop/node_modules/request/request.js:578:7)
[0]     at processImmediate (internal/timers.js:439:21)
[0] 11:36:14.414 › Killing session for window with id: 3
```

I checked https works on AppiumDesktop with this change.