### PR TITLE
fix default value from jsonWireCall

### DIFF
--- a/lib/webdriver.js
+++ b/lib/webdriver.js
@@ -199,7 +199,7 @@ Webdriver.prototype._jsonWireCall = function(opts) {
   httpUtils.requestWithRetry(httpOpts, this._httpConfig, this.emit.bind(this), function(err, res, data) {
     if(err) { return cb(err); }
     data = strip(data);
-    cb(null, data || "");
+    cb(null, data || "{}");
   });
 };
 


### PR DESCRIPTION
Hi @admc,

I lack alot of background but shouldn't  the default value be parsable by JSON.parse?